### PR TITLE
Restrict client functionality for business accounts

### DIFF
--- a/src/hooks/useClients.ts
+++ b/src/hooks/useClients.ts
@@ -1,4 +1,5 @@
 import { useState, useEffect } from 'react';
+import { useAuth } from './useAuth';
 import { Client } from '../types';
 
 // Mock clients data
@@ -579,16 +580,33 @@ const defaultFinancials: Client['financials'] = {
 export const useClients = () => {
   const [clients, setClients] = useState<Client[]>([]);
   const [isLoading, setIsLoading] = useState(true);
+  const { user } = useAuth();
 
   useEffect(() => {
+    setIsLoading(true);
+
+    if (user?.accountType === 'business') {
+      setClients([]);
+      setIsLoading(false);
+      return;
+    }
+
     // Simulate API call
-    setTimeout(() => {
+    const timeout = setTimeout(() => {
       setClients(mockClients);
       setIsLoading(false);
     }, 1000);
-  }, []);
 
-  const createClient = (clientData: ClientInput) => {
+    return () => {
+      clearTimeout(timeout);
+    };
+  }, [user?.accountType]);
+
+  const createClient = (clientData: ClientInput): Client | null => {
+    if (user?.accountType === 'business') {
+      return null;
+    }
+
     const timestamp = new Date().toISOString();
     const newClient: Client = {
       id: Date.now().toString(),
@@ -621,6 +639,10 @@ export const useClients = () => {
   };
 
   const updateClient = (id: string, updates: Partial<Client>) => {
+    if (user?.accountType === 'business') {
+      return;
+    }
+
     setClients(prev => prev.map(client => {
       if (client.id !== id) {
         return client;
@@ -652,6 +674,10 @@ export const useClients = () => {
   };
 
   const deleteClient = (id: string) => {
+    if (user?.accountType === 'business') {
+      return;
+    }
+
     setClients(prev => prev.filter(client => client.id !== id));
   };
 

--- a/src/views/Workspaces.tsx
+++ b/src/views/Workspaces.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import { Search, Filter, PlusCircle } from 'lucide-react';
 import { useClients } from '../hooks/useClients';
 import { useProjects } from '../hooks/useProjects';
@@ -34,7 +34,19 @@ const Workspaces: React.FC = () => {
   const [activeTypes, setActiveTypes] = useState<WorkspaceType[]>([...typeOrder]);
   const [statusFilter, setStatusFilter] = useState<string>('all');
   const [formState, setFormState] = useState<FormState | null>(null);
-  const [createType, setCreateType] = useState<WorkspaceType>('client');
+  const creationTypeOptions = useMemo<WorkspaceType[]>(
+    () => (user?.accountType === 'business' ? ['project', 'team'] : [...typeOrder]),
+    [user?.accountType]
+  );
+  const [createType, setCreateType] = useState<WorkspaceType>(() =>
+    user?.accountType === 'business' ? 'project' : 'client'
+  );
+
+  useEffect(() => {
+    if (creationTypeOptions.length > 0 && !creationTypeOptions.includes(createType)) {
+      setCreateType(creationTypeOptions[0]);
+    }
+  }, [createType, creationTypeOptions]);
 
   const isLoading = loadingClients || loadingProjects || loadingTeam;
 
@@ -282,7 +294,7 @@ const Workspaces: React.FC = () => {
                   value={createType}
                   onChange={(event) => setCreateType(event.target.value as WorkspaceType)}
                 >
-                  {typeOrder.map((type) => (
+                  {creationTypeOptions.map((type) => (
                     <option key={`create-${type}`} value={type}>
                       {typeLabels[type]}
                     </option>


### PR DESCRIPTION
## Summary
- guard the clients hook with the authenticated account type so business users no longer receive mock clients or mutate client data
- adjust the workspaces create menu to default to non-client entities and hide the client option for business accounts

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cf424c6484832da9bdaeb95544eff4