### PR TITLE
Refine button styles and layout spacing

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -54,13 +54,11 @@ const AppContent: React.FC = () => {
   return (
     <div className="min-h-screen flex flex-col bg-[var(--bg-start)]">
       <Header />
-      <div className="flex-1 flex">
+      <div className="flex flex-1 min-h-0">
         <Sidebar activeView={activeView} onViewChange={setActiveView} />
-        <div className="flex-1 flex flex-col">
-          <main className="flex-1 p-6 overflow-auto">
-            {renderContent()}
-          </main>
-        </div>
+        <main className="flex-1 min-h-0 overflow-y-auto p-4 md:p-6">
+          {renderContent()}
+        </main>
       </div>
       <Footer />
     </div>

--- a/src/components/Auth/LoginForm.tsx
+++ b/src/components/Auth/LoginForm.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import { Eye, EyeOff } from 'lucide-react';
 import { useAuth } from '../../hooks/useAuth';
+import { Button } from '../Shared/Button';
 
 const demoAccounts = [
   { email: 'agency-owner@demo.com', label: 'Agency Owner', description: 'Full access to all agency features' },
@@ -104,13 +105,15 @@ const LoginForm: React.FC = () => {
               </div>
             )}
 
-            <button
+            <Button
               type="submit"
               disabled={isLoading}
-              className="w-full bg-gradient-primary text-white font-semibold py-3 px-4 rounded-lg hover:opacity-90 focus:outline-none focus:ring-2 focus:ring-sunset-purple focus:ring-offset-2 focus:ring-offset-[var(--bg-start)] transition-all disabled:opacity-50 disabled:cursor-not-allowed"
+              glowOnHover
+              className="w-full"
+              innerClassName="justify-center py-3 font-semibold"
             >
               {isLoading ? 'Signing In...' : 'Sign In'}
-            </button>
+            </Button>
           </form>
 
           <div className="mt-8 space-y-4">

--- a/src/components/Auth/LoginForm.tsx
+++ b/src/components/Auth/LoginForm.tsx
@@ -109,8 +109,8 @@ const LoginForm: React.FC = () => {
               type="submit"
               disabled={isLoading}
               glowOnHover
-              className="w-full"
-              innerClassName="justify-center py-3 font-semibold"
+              wrapperClassName="w-full"
+              className="w-full justify-center py-3 font-semibold"
             >
               {isLoading ? 'Signing In...' : 'Sign In'}
             </Button>

--- a/src/components/Clients/ClientDetails.tsx
+++ b/src/components/Clients/ClientDetails.tsx
@@ -8,6 +8,7 @@ import ProjectModal from '../Projects/ProjectModal';
 import { useTeam } from '../../hooks/useTeam';
 import { useProjects } from '../../hooks/useProjects';
 import { useTools } from '../../hooks/useTools';
+import { Button } from '../Shared/Button';
 
 interface ClientDetailsProps {
   client: Client;
@@ -268,15 +269,29 @@ const ClientDetails: React.FC<ClientDetailsProps> = ({ client, onBack }) => {
           <div className="bg-glass-gradient-light dark:bg-glass-gradient-dark border border-glass-border-light dark:border-glass-border-dark rounded-xl p-6 backdrop-blur-md shadow-lg">
             <h3 className="text-lg font-semibold text-gray-900 dark:text-white mb-4">Actions</h3>
             <div className="space-y-3">
-              <button className="w-full bg-sunset-orange text-white font-semibold py-2 px-4 rounded-lg hover:opacity-90 transition-opacity">
+              <Button
+                glowOnHover
+                wrapperClassName="w-full"
+                className="w-full justify-center font-semibold text-white group-hover:text-white group-focus-within:text-white"
+              >
                 New Project
-              </button>
-              <button className="w-full bg-white/30 dark:bg-white/10 text-gray-900 dark:text-white font-semibold py-2 px-4 rounded-lg hover:bg-white/40 dark:hover:bg-white/15 transition-colors backdrop-blur-sm">
+              </Button>
+              <Button
+                variant="secondary"
+                appearance="solid"
+                wrapperClassName="w-full"
+                className="w-full justify-center font-semibold border-transparent bg-white/30 text-gray-900 hover:bg-white/40 dark:bg-white/10 dark:text-white dark:hover:bg-white/15 backdrop-blur-sm"
+              >
                 Edit Client
-              </button>
-              <button className="w-full bg-white/30 dark:bg-white/10 text-gray-900 dark:text-white font-semibold py-2 px-4 rounded-lg hover:bg-white/40 dark:hover:bg-white/15 transition-colors backdrop-blur-sm">
+              </Button>
+              <Button
+                variant="secondary"
+                appearance="solid"
+                wrapperClassName="w-full"
+                className="w-full justify-center font-semibold border-transparent bg-white/30 text-gray-900 hover:bg-white/40 dark:bg-white/10 dark:text-white dark:hover:bg-white/15 backdrop-blur-sm"
+              >
                 Add Contact
-              </button>
+              </Button>
             </div>
           </div>
         </div>

--- a/src/components/Layout/AccountModal.tsx
+++ b/src/components/Layout/AccountModal.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import { X, User, Building2, Save, Edit3 } from 'lucide-react';
+import { Button } from '../Shared/Button';
 import { User as UserType, Account } from '../../types';
 
 interface AccountModalProps {
@@ -178,13 +179,10 @@ const AccountModal: React.FC<AccountModalProps> = ({ user, account, onClose }) =
               >
                 Cancel
               </button>
-              <button
-                onClick={handleSave}
-                className="px-4 py-2 bg-gradient-primary text-white rounded-lg hover:opacity-90 transition-opacity flex items-center space-x-2"
-              >
+              <Button onClick={handleSave} glowOnHover innerClassName="font-semibold">
                 <Save className="w-4 h-4" />
                 <span>Save Changes</span>
-              </button>
+              </Button>
             </div>
           )}
         </div>

--- a/src/components/Layout/AccountModal.tsx
+++ b/src/components/Layout/AccountModal.tsx
@@ -173,13 +173,15 @@ const AccountModal: React.FC<AccountModalProps> = ({ user, account, onClose }) =
           {/* Actions */}
           {isEditing && (
             <div className="flex justify-end space-x-3">
-              <button
+              <Button
                 onClick={() => setIsEditing(false)}
-                className="px-4 py-2 text-gray-600 dark:text-gray-300 hover:text-gray-900 dark:hover:text-white rounded-lg transition-colors"
+                appearance="outline"
+                size="sm"
+                className="text-gray-600 dark:text-gray-300"
               >
                 Cancel
-              </button>
-              <Button onClick={handleSave} glowOnHover innerClassName="font-semibold">
+              </Button>
+              <Button onClick={handleSave} glowOnHover className="font-semibold">
                 <Save className="w-4 h-4" />
                 <span>Save Changes</span>
               </Button>

--- a/src/components/Layout/Header.tsx
+++ b/src/components/Layout/Header.tsx
@@ -13,9 +13,9 @@ export function Header() {
   return (
     <>
       <header className="sticky top-0 z-50 border-b border-[var(--border)] bg-[var(--header)] backdrop-blur-md supports-[backdrop-filter]:bg-[var(--header)]">
-        <div className="flex items-center justify-between px-4 py-3">
-          <div className="flex items-center gap-6">
-            <Logo className="h-20 w-auto" />
+        <div className="flex items-center justify-between px-4 py-2.5">
+          <div className="flex items-center gap-4">
+            <Logo className="h-12 w-auto" />
             {account && (
               <div className="text-2xl font-bold text-[var(--fg)]">
                 {account.name}

--- a/src/components/Layout/Header.tsx
+++ b/src/components/Layout/Header.tsx
@@ -13,9 +13,9 @@ export function Header() {
   return (
     <>
       <header className="sticky top-0 z-50 border-b border-[var(--border)] bg-[var(--header)] backdrop-blur-md supports-[backdrop-filter]:bg-[var(--header)]">
-        <div className="flex h-20 items-center justify-between px-2">
-          <div className="flex items-center gap-8">
-            <Logo className="h-36 w-auto" />
+        <div className="flex items-center justify-between px-4 py-3">
+          <div className="flex items-center gap-6">
+            <Logo className="h-20 w-auto" />
             {account && (
               <div className="text-2xl font-bold text-[var(--fg)]">
                 {account.name}

--- a/src/components/Layout/Sidebar.tsx
+++ b/src/components/Layout/Sidebar.tsx
@@ -28,7 +28,7 @@ const Sidebar: React.FC<SidebarProps> = ({ activeView, onViewChange }) => {
   const menuItems = allMenuItems.filter(item => availablePages.includes(item.id));
 
   return (
-    <div className="w-64 flex-shrink-0 bg-[var(--bg-start)] border-r border-[var(--border)] flex flex-col">
+    <div className="w-64 flex-shrink-0 bg-[var(--bg-start)] border-r border-[var(--border)] flex flex-col min-h-screen">
       <nav className="flex-1 p-4">
         <div className="flex items-center justify-between px-2 pb-6">
           <Logo className="h-10 w-auto" showText />

--- a/src/components/Layout/Sidebar.tsx
+++ b/src/components/Layout/Sidebar.tsx
@@ -28,7 +28,7 @@ const Sidebar: React.FC<SidebarProps> = ({ activeView, onViewChange }) => {
   const menuItems = allMenuItems.filter(item => availablePages.includes(item.id));
 
   return (
-    <div className="w-64 bg-[var(--bg-start)] border-r border-[var(--border)] flex flex-col">
+    <div className="w-64 flex-shrink-0 bg-[var(--bg-start)] border-r border-[var(--border)] flex flex-col">
       <nav className="flex-1 p-4">
         <div className="flex items-center justify-between px-2 pb-6">
           <Logo className="h-10 w-auto" showText />

--- a/src/components/Projects/ClientModal.tsx
+++ b/src/components/Projects/ClientModal.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { X, Building2, MapPin, Globe, Linkedin, Mail, Phone, User, ExternalLink, Calendar, Users, FolderOpen, Wrench, BarChart3, DollarSign } from 'lucide-react';
 import { Client } from '../../types';
 import { useAuth } from '../../hooks/useAuth';
+import { Button } from '../Shared/Button';
 
 interface ClientModalProps {
   client: Client;

--- a/src/components/Projects/ClientModal.tsx
+++ b/src/components/Projects/ClientModal.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import { X, Building2, MapPin, Globe, Linkedin, Mail, Phone, User, ExternalLink, Calendar, Users, FolderOpen, Wrench, BarChart3, DollarSign } from 'lucide-react';
 import { Client } from '../../types';
 import { useAuth } from '../../hooks/useAuth';
-import { Button } from '../Shared/Button';
 
 interface ClientModalProps {
   client: Client;

--- a/src/components/Projects/ProjectModal.tsx
+++ b/src/components/Projects/ProjectModal.tsx
@@ -167,23 +167,23 @@ const ProjectModal: React.FC<ProjectModalProps> = ({ project, onClose }) => {
                 <h4 className="text-lg font-semibold text-gray-900 dark:text-white mb-4">Quick Actions</h4>
                 <div className="space-y-3">
                   <Button
-                    className="w-full"
                     glowOnHover
-                    innerClassName="justify-center font-semibold"
+                    wrapperClassName="w-full"
+                    className="w-full justify-center font-semibold text-white group-hover:text-white group-focus-within:text-white"
                   >
                     Add System
                   </Button>
                   <Button
-                    className="w-full"
                     appearance="solid"
-                    innerClassName="justify-center font-semibold"
+                    wrapperClassName="w-full"
+                    className="w-full justify-center font-semibold"
                   >
                     Edit Project
                   </Button>
                   <Button
-                    className="w-full"
                     appearance="outline"
-                    innerClassName="justify-center font-semibold"
+                    wrapperClassName="w-full"
+                    className="w-full justify-center font-semibold"
                   >
                     View Analytics
                   </Button>
@@ -249,10 +249,10 @@ const ProjectModal: React.FC<ProjectModalProps> = ({ project, onClose }) => {
                   <Button
                     key={projectManager.id}
                     onClick={() => setSelectedTeamMember(projectManager)}
-                    className="w-full"
                     appearance="solid"
                     glowOnHover
-                    innerClassName="w-full justify-start px-3 py-3 text-left"
+                    wrapperClassName="w-full"
+                    className="w-full justify-start px-3 py-3 text-left"
                   >
                     <div className="flex items-center space-x-3 w-full">
                       <div className="w-8 h-8 bg-gradient-primary rounded-full flex items-center justify-center">

--- a/src/components/Projects/ProjectModal.tsx
+++ b/src/components/Projects/ProjectModal.tsx
@@ -6,6 +6,7 @@ import { useTeam } from '../../hooks/useTeam';
 import { useAuth } from '../../hooks/useAuth';
 import TeamMemberModal from '../Clients/TeamMemberModal';
 import ClientModal from './ClientModal';
+import { Button } from '../Shared/Button';
 
 interface ProjectModalProps {
   project: Project;
@@ -165,15 +166,27 @@ const ProjectModal: React.FC<ProjectModalProps> = ({ project, onClose }) => {
               <div className="bg-white/20 dark:bg-white/10 border border-white/20 dark:border-white/10 rounded-xl p-6 backdrop-blur-sm">
                 <h4 className="text-lg font-semibold text-gray-900 dark:text-white mb-4">Quick Actions</h4>
                 <div className="space-y-3">
-                  <button className="w-full bg-gradient-primary text-white font-semibold py-2 px-4 rounded-lg hover:opacity-90 transition-opacity">
+                  <Button
+                    className="w-full"
+                    glowOnHover
+                    innerClassName="justify-center font-semibold"
+                  >
                     Add System
-                  </button>
-                  <button className="w-full bg-white/30 dark:bg-white/10 text-gray-900 dark:text-white font-semibold py-2 px-4 rounded-lg hover:bg-white/40 dark:hover:bg-white/15 transition-colors backdrop-blur-sm">
+                  </Button>
+                  <Button
+                    className="w-full"
+                    appearance="solid"
+                    innerClassName="justify-center font-semibold"
+                  >
                     Edit Project
-                  </button>
-                  <button className="w-full bg-white/30 dark:bg-white/10 text-gray-900 dark:text-white font-semibold py-2 px-4 rounded-lg hover:bg-white/40 dark:hover:bg-white/15 transition-colors backdrop-blur-sm">
+                  </Button>
+                  <Button
+                    className="w-full"
+                    appearance="outline"
+                    innerClassName="justify-center font-semibold"
+                  >
                     View Analytics
-                  </button>
+                  </Button>
                 </div>
               </div>
             </div>
@@ -233,22 +246,27 @@ const ProjectModal: React.FC<ProjectModalProps> = ({ project, onClose }) => {
               </h4>
               <div className="space-y-3 max-h-64 overflow-y-auto">
                 {projectManager && user?.accountType === 'agency' && (
-                  <div 
+                  <Button
                     key={projectManager.id}
                     onClick={() => setSelectedTeamMember(projectManager)}
-                    className="flex items-center space-x-3 p-3 bg-gradient-primary rounded-lg cursor-pointer hover:opacity-90 transition-opacity"
+                    className="w-full"
+                    appearance="solid"
+                    glowOnHover
+                    innerClassName="w-full justify-start px-3 py-3 text-left"
                   >
-                    <div className="w-8 h-8 bg-white/20 rounded-full flex items-center justify-center">
-                      <span className="text-sm font-bold text-white">
-                        {projectManager.name.split(' ').map(n => n[0]).join('')}
-                      </span>
+                    <div className="flex items-center space-x-3 w-full">
+                      <div className="w-8 h-8 bg-gradient-primary rounded-full flex items-center justify-center">
+                        <span className="text-sm font-bold text-white">
+                          {projectManager.name.split(' ').map(n => n[0]).join('')}
+                        </span>
+                      </div>
+                      <div className="flex-1">
+                        <p className="text-sm font-medium text-[var(--fg)]">{projectManager.name}</p>
+                        <p className="text-xs text-[var(--fg-muted)]">Project Manager</p>
+                      </div>
+                      <div className="w-2 h-2 rounded-full bg-[var(--accent-orange)]" />
                     </div>
-                    <div className="flex-1">
-                      <p className="text-sm font-medium text-white">{projectManager.name}</p>
-                      <p className="text-xs text-white/80">Project Manager</p>
-                    </div>
-                    <div className="w-2 h-2 rounded-full bg-white" />
-                  </div>
+                  </Button>
                 )}
                 {assignedTeamMembers.map((member) => (
                   <div 

--- a/src/components/Shared/Button.tsx
+++ b/src/components/Shared/Button.tsx
@@ -37,7 +37,7 @@ interface ButtonProps {
   appearance?: ButtonAppearance;
   size?: 'sm' | 'md' | 'lg';
   className?: string;
-  innerClassName?: string;
+  wrapperClassName?: string;
   onClick?: () => void;
   href?: string;
   disabled?: boolean;
@@ -52,7 +52,7 @@ export function Button({
   appearance,
   size = 'md',
   className = '',
-  innerClassName = '',
+  wrapperClassName = '',
   onClick,
   href,
   disabled = false,
@@ -72,7 +72,7 @@ export function Button({
     variantClasses[variant],
     appearanceClasses[resolvedAppearance],
     variant === 'ghost' ? 'border border-transparent bg-transparent hover:bg-[var(--surface)] focus-visible:ring-2 focus-visible:ring-[var(--accent-purple)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--bg-start)]' : undefined,
-    innerClassName,
+    className,
   );
 
   const overlayClasses = cx(
@@ -80,39 +80,38 @@ export function Button({
     activeGlow ? 'opacity-80' : resolvedGlowOnHover ? 'opacity-0 group-hover:opacity-80 group-focus-within:opacity-80' : 'opacity-0',
   );
 
-  if (useGlowWrapper) {
-    if (href) {
-      return (
-        <div className={cx('relative inline-flex group', disabled ? 'pointer-events-none' : undefined, className)}>
-          <div className={overlayClasses} style={{ filter: 'blur(2px)' }} aria-hidden="true" />
-          <a href={href} onClick={onClick} className={buttonClasses}>
-            {children}
-          </a>
-        </div>
-      );
-    }
+  const content = href ? (
+    <a
+      href={href}
+      onClick={
+        disabled
+          ? (event: React.MouseEvent<HTMLAnchorElement>) => event.preventDefault()
+          : onClick
+      }
+      className={cx(buttonClasses, disabled ? 'pointer-events-none' : undefined)}
+      aria-disabled={disabled ? 'true' : undefined}
+      tabIndex={disabled ? -1 : undefined}
+    >
+      {children}
+    </a>
+  ) : (
+    <button type={type} onClick={onClick} disabled={disabled} className={buttonClasses}>
+      {children}
+    </button>
+  );
 
+  if (useGlowWrapper) {
     return (
-      <div className={cx('relative inline-flex group', disabled ? 'pointer-events-none' : undefined, className)}>
+      <div className={cx('relative inline-flex group', disabled ? 'pointer-events-none' : undefined, wrapperClassName)}>
         <div className={overlayClasses} style={{ filter: 'blur(2px)' }} aria-hidden="true" />
-        <button type={type} onClick={onClick} disabled={disabled} className={buttonClasses}>
-          {children}
-        </button>
+        {content}
       </div>
     );
   }
 
-  if (href) {
-    return (
-      <a href={href} onClick={onClick} className={cx(buttonClasses, className)}>
-        {children}
-      </a>
-    );
+  if (wrapperClassName) {
+    return <div className={wrapperClassName}>{content}</div>;
   }
 
-  return (
-    <button type={type} onClick={onClick} disabled={disabled} className={cx(buttonClasses, className)}>
-      {children}
-    </button>
-  );
+  return content;
 }

--- a/src/components/Shared/Button.tsx
+++ b/src/components/Shared/Button.tsx
@@ -1,10 +1,43 @@
 import React from 'react';
 
+type ButtonVariant = 'primary' | 'secondary' | 'ghost' | 'outline';
+type ButtonAppearance = 'glow' | 'solid' | 'outline';
+
+const cx = (...classes: (string | false | undefined)[]) => classes.filter(Boolean).join(' ');
+
+const sizeClasses: Record<'sm' | 'md' | 'lg', string> = {
+  sm: 'px-3 py-1.5 text-sm',
+  md: 'px-4 py-2 text-sm',
+  lg: 'px-6 py-3 text-base',
+};
+
+const variantClasses: Record<ButtonVariant, string> = {
+  primary: 'text-[var(--fg)]',
+  secondary: 'text-[var(--fg)]',
+  ghost: 'text-[var(--fg-muted)] hover:text-[var(--fg)] focus-visible:text-[var(--fg)]',
+  outline: 'text-[var(--fg)]',
+};
+
+const defaultAppearanceByVariant: Record<ButtonVariant, ButtonAppearance> = {
+  primary: 'glow',
+  secondary: 'solid',
+  ghost: 'outline',
+  outline: 'outline',
+};
+
+const appearanceClasses: Record<ButtonAppearance, string> = {
+  glow: 'border border-transparent bg-[var(--card)] shadow-sm group-hover:bg-[var(--surface)] group-focus-within:bg-[var(--surface)] group-hover:text-[var(--fg)] group-focus-within:text-[var(--fg)] focus-visible:ring-0 focus-visible:ring-offset-0',
+  solid: 'border border-[var(--border)] bg-[var(--card)] shadow-sm hover:bg-[var(--surface)] focus-visible:ring-2 focus-visible:ring-[var(--accent-purple)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--bg-start)]',
+  outline: 'border border-[var(--border)] bg-transparent hover:bg-[var(--surface)] focus-visible:ring-2 focus-visible:ring-[var(--accent-purple)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--bg-start)]',
+};
+
 interface ButtonProps {
   children: React.ReactNode;
-  variant?: 'primary' | 'secondary' | 'ghost' | 'outline';
+  variant?: ButtonVariant;
+  appearance?: ButtonAppearance;
   size?: 'sm' | 'md' | 'lg';
   className?: string;
+  innerClassName?: string;
   onClick?: () => void;
   href?: string;
   disabled?: boolean;
@@ -16,91 +49,69 @@ interface ButtonProps {
 export function Button({
   children,
   variant = 'primary',
+  appearance,
   size = 'md',
   className = '',
+  innerClassName = '',
   onClick,
   href,
   disabled = false,
   type = 'button',
-  glowOnHover = false,
+  glowOnHover = true,
   activeGlow = false,
 }: ButtonProps) {
-  const baseClasses = 'inline-flex items-center justify-center font-medium rounded-lg transition-all duration-200 focus:outline-none focus:ring-2 focus:ring-offset-2';
-  
-  const variantClasses = {
-    primary: 'bg-[var(--card)] text-[var(--fg)] focus:ring-[var(--accent-orange)] shadow-sm',
-    secondary: 'bg-[var(--card)] text-[var(--fg)] focus:ring-[var(--accent-mid)] shadow-sm',
-    ghost: 'text-[var(--fg-muted)] focus:ring-[var(--accent-mid)] hover:bg-[var(--card)] shadow-sm',
-    outline: 'border border-[var(--border)] text-[var(--fg)] focus:ring-[var(--accent-mid)] hover:bg-[var(--card)] shadow-sm'
-  };
-  
-  const sizeClasses = {
-    sm: 'px-3 py-1.5 text-sm',
-    md: 'px-4 py-2 text-sm',
-    lg: 'px-6 py-3 text-base'
-  };
-  
-  const disabledClasses = disabled 
-    ? 'opacity-50 cursor-not-allowed' 
-    : '';
-  
-  const buttonClasses = `${baseClasses} ${variantClasses[variant]} ${sizeClasses[size]} ${disabledClasses} relative z-10`;
-  
-  if (glowOnHover || activeGlow) {
+  const baseClasses = 'relative inline-flex items-center justify-center gap-2 font-medium rounded-lg transition-all duration-200 disabled:opacity-50 disabled:cursor-not-allowed focus-visible:outline-none';
+
+  const resolvedAppearance: ButtonAppearance = appearance ?? defaultAppearanceByVariant[variant];
+  const useGlowWrapper = resolvedAppearance === 'glow';
+  const resolvedGlowOnHover = useGlowWrapper ? glowOnHover : false;
+
+  const buttonClasses = cx(
+    baseClasses,
+    sizeClasses[size],
+    variantClasses[variant],
+    appearanceClasses[resolvedAppearance],
+    variant === 'ghost' ? 'border border-transparent bg-transparent hover:bg-[var(--surface)] focus-visible:ring-2 focus-visible:ring-[var(--accent-purple)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--bg-start)]' : undefined,
+    innerClassName,
+  );
+
+  const overlayClasses = cx(
+    'absolute -inset-0.5 rounded-lg bg-gradient-to-r from-[var(--accent-orange)] via-[var(--accent-pink)] to-[var(--accent-purple)] transition-opacity duration-300 pointer-events-none',
+    activeGlow ? 'opacity-80' : resolvedGlowOnHover ? 'opacity-0 group-hover:opacity-80 group-focus-within:opacity-80' : 'opacity-0',
+  );
+
+  if (useGlowWrapper) {
     if (href) {
       return (
-        <div className={`relative group ${className}`}>
-          <div 
-            className={`absolute -inset-0.5 bg-gradient-to-r from-[var(--accent-orange)] via-[var(--accent-pink)] to-[var(--accent-purple)] rounded-lg transition-opacity duration-300 z-0 ${
-              activeGlow ? 'opacity-100' : glowOnHover ? 'opacity-0 group-hover:opacity-100' : 'opacity-0'
-            }`}
-            style={{ filter: 'blur(2px)' }}
-            aria-hidden="true"
-          />
-          <a href={href} className={buttonClasses}>
+        <div className={cx('relative inline-flex group', disabled ? 'pointer-events-none' : undefined, className)}>
+          <div className={overlayClasses} style={{ filter: 'blur(2px)' }} aria-hidden="true" />
+          <a href={href} onClick={onClick} className={buttonClasses}>
             {children}
           </a>
         </div>
       );
     }
-    
+
     return (
-      <div className={`relative group ${className}`}>
-        <div 
-          className={`absolute -inset-0.5 bg-gradient-to-r from-[var(--accent-orange)] via-[var(--accent-pink)] to-[var(--accent-purple)] rounded-lg transition-opacity duration-300 z-0 ${
-            activeGlow ? 'opacity-75' : glowOnHover ? 'opacity-0 group-hover:opacity-75' : 'opacity-0'
-          }`}
-          style={{ filter: 'blur(2px)' }}
-          aria-hidden="true"
-        />
-        <button
-          type={type}
-          onClick={onClick}
-          disabled={disabled}
-          className={buttonClasses}
-        >
+      <div className={cx('relative inline-flex group', disabled ? 'pointer-events-none' : undefined, className)}>
+        <div className={overlayClasses} style={{ filter: 'blur(2px)' }} aria-hidden="true" />
+        <button type={type} onClick={onClick} disabled={disabled} className={buttonClasses}>
           {children}
         </button>
       </div>
     );
   }
-  
-  // No glow version
+
   if (href) {
     return (
-      <a href={href} className={`${buttonClasses} ${className}`}>
+      <a href={href} onClick={onClick} className={cx(buttonClasses, className)}>
         {children}
       </a>
     );
   }
-  
+
   return (
-    <button
-      type={type}
-      onClick={onClick}
-      disabled={disabled}
-      className={`${buttonClasses} ${className}`}
-    >
+    <button type={type} onClick={onClick} disabled={disabled} className={cx(buttonClasses, className)}>
       {children}
     </button>
   );

--- a/src/components/Shared/EntityFormModal.tsx
+++ b/src/components/Shared/EntityFormModal.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useMemo, useState } from 'react';
 import { X, Building2, FolderOpen, Users, Wrench, Save, Sparkles } from 'lucide-react';
+import { Button } from './Button';
 import { Client, Project, TeamMember } from '../../types';
 import { Tool } from '../../types/tools';
 
@@ -229,13 +230,10 @@ const ClientForm: React.FC<ClientFormProps> = ({ mode, initialData, onSubmit, on
         >
           Cancel
         </button>
-        <button
-          type="submit"
-          className="px-4 py-2 rounded-lg bg-gradient-to-r from-[var(--accent-orange)] via-[var(--accent-pink)] to-[var(--accent-purple)] text-white font-semibold flex items-center gap-2"
-        >
+        <Button type="submit" glowOnHover innerClassName="font-semibold">
           <Save className="w-4 h-4" />
           {mode === 'create' ? 'Add Client' : 'Save Changes'}
-        </button>
+        </Button>
       </div>
     </form>
   );
@@ -351,13 +349,10 @@ const ProjectForm: React.FC<ProjectFormProps> = ({ mode, initialData, clients, t
         >
           Cancel
         </button>
-        <button
-          type="submit"
-          className="px-4 py-2 rounded-lg bg-gradient-to-r from-[var(--accent-orange)] via-[var(--accent-pink)] to-[var(--accent-purple)] text-white font-semibold flex items-center gap-2"
-        >
+        <Button type="submit" glowOnHover innerClassName="font-semibold">
           <Save className="w-4 h-4" />
           {mode === 'create' ? 'Add Project' : 'Save Changes'}
-        </button>
+        </Button>
       </div>
     </form>
   );
@@ -496,13 +491,10 @@ const TeamForm: React.FC<TeamFormProps> = ({ mode, initialData, onSubmit, onCanc
         >
           Cancel
         </button>
-        <button
-          type="submit"
-          className="px-4 py-2 rounded-lg bg-gradient-to-r from-[var(--accent-orange)] via-[var(--accent-pink)] to-[var(--accent-purple)] text-white font-semibold flex items-center gap-2"
-        >
+        <Button type="submit" glowOnHover innerClassName="font-semibold">
           <Save className="w-4 h-4" />
           {mode === 'create' ? 'Add Team Member' : 'Save Changes'}
-        </button>
+        </Button>
       </div>
     </form>
   );
@@ -786,13 +778,10 @@ const ToolForm: React.FC<ToolFormProps> = ({ mode, initialData, clients, project
         >
           Cancel
         </button>
-        <button
-          type="submit"
-          className="px-4 py-2 rounded-lg bg-gradient-to-r from-[var(--accent-orange)] via-[var(--accent-pink)] to-[var(--accent-purple)] text-white font-semibold flex items-center gap-2"
-        >
+        <Button type="submit" glowOnHover innerClassName="font-semibold">
           <Sparkles className="w-4 h-4" />
           {mode === 'create' ? 'Create Tool' : 'Save Changes'}
-        </button>
+        </Button>
       </div>
     </form>
   );

--- a/src/components/Shared/EntityFormModal.tsx
+++ b/src/components/Shared/EntityFormModal.tsx
@@ -63,6 +63,7 @@ interface EntityFormModalProps {
   teamMembers?: TeamMember[];
   onClose: () => void;
   onSubmit: (values: EntityFormValues) => void;
+  defaultClientId?: string;
 }
 
 type ClientFormProps = {
@@ -79,6 +80,7 @@ type ProjectFormProps = {
   teamMembers: TeamMember[];
   onSubmit: (values: ProjectFormValues) => void;
   onCancel: () => void;
+  defaultClientId?: string;
 };
 
 type TeamFormProps = {
@@ -241,12 +243,12 @@ const ClientForm: React.FC<ClientFormProps> = ({ mode, initialData, onSubmit, on
   );
 };
 
-const ProjectForm: React.FC<ProjectFormProps> = ({ mode, initialData, clients, teamMembers, onSubmit, onCancel }) => {
+const ProjectForm: React.FC<ProjectFormProps> = ({ mode, initialData, clients, teamMembers, onSubmit, onCancel, defaultClientId }) => {
   const [formValues, setFormValues] = useState<ProjectFormValues>({
     name: initialData?.name || '',
     description: initialData?.description || '',
     status: initialData?.status || 'planning',
-    clientId: initialData?.clientId || (clients[0]?.id ?? ''),
+    clientId: initialData?.clientId || defaultClientId || (clients[0]?.id ?? ''),
     assignedUsers: initialData?.assignedUsers || [],
   });
 
@@ -255,10 +257,10 @@ const ProjectForm: React.FC<ProjectFormProps> = ({ mode, initialData, clients, t
       name: initialData?.name || '',
       description: initialData?.description || '',
       status: initialData?.status || 'planning',
-      clientId: initialData?.clientId || (clients[0]?.id ?? ''),
+      clientId: initialData?.clientId || defaultClientId || (clients[0]?.id ?? ''),
       assignedUsers: initialData?.assignedUsers || [],
     });
-  }, [initialData, clients]);
+  }, [initialData, clients, defaultClientId]);
 
   const toggleUser = (userId: string) => {
     setFormValues((prev) => ({
@@ -826,6 +828,7 @@ export const EntityFormModal: React.FC<EntityFormModalProps> = ({
   teamMembers = [],
   onClose,
   onSubmit,
+  defaultClientId,
 }) => {
   if (!isOpen) return null;
 
@@ -873,6 +876,7 @@ export const EntityFormModal: React.FC<EntityFormModalProps> = ({
               initialData={initialData as Project | null}
               clients={clients}
               teamMembers={teamMembers}
+              defaultClientId={defaultClientId}
               onSubmit={onSubmit as (values: ProjectFormValues) => void}
               onCancel={onClose}
             />

--- a/src/components/Shared/EntityFormModal.tsx
+++ b/src/components/Shared/EntityFormModal.tsx
@@ -223,14 +223,16 @@ const ClientForm: React.FC<ClientFormProps> = ({ mode, initialData, onSubmit, on
       </Section>
 
       <div className="flex items-center justify-end gap-3">
-        <button
+        <Button
           type="button"
           onClick={onCancel}
-          className="px-4 py-2 rounded-lg border border-[var(--border)] text-[var(--fg)] hover:bg-[var(--surface)] transition"
+          appearance="outline"
+          size="sm"
+          className="text-[var(--fg)]"
         >
           Cancel
-        </button>
-        <Button type="submit" glowOnHover innerClassName="font-semibold">
+        </Button>
+        <Button type="submit" glowOnHover className="font-semibold">
           <Save className="w-4 h-4" />
           {mode === 'create' ? 'Add Client' : 'Save Changes'}
         </Button>
@@ -342,14 +344,16 @@ const ProjectForm: React.FC<ProjectFormProps> = ({ mode, initialData, clients, t
       </Section>
 
       <div className="flex items-center justify-end gap-3">
-        <button
+        <Button
           type="button"
           onClick={onCancel}
-          className="px-4 py-2 rounded-lg border border-[var(--border)] text-[var(--fg)] hover:bg-[var(--surface)] transition"
+          appearance="outline"
+          size="sm"
+          className="text-[var(--fg)]"
         >
           Cancel
-        </button>
-        <Button type="submit" glowOnHover innerClassName="font-semibold">
+        </Button>
+        <Button type="submit" glowOnHover className="font-semibold">
           <Save className="w-4 h-4" />
           {mode === 'create' ? 'Add Project' : 'Save Changes'}
         </Button>
@@ -484,14 +488,16 @@ const TeamForm: React.FC<TeamFormProps> = ({ mode, initialData, onSubmit, onCanc
       </Section>
 
       <div className="flex items-center justify-end gap-3">
-        <button
+        <Button
           type="button"
           onClick={onCancel}
-          className="px-4 py-2 rounded-lg border border-[var(--border)] text-[var(--fg)] hover:bg-[var(--surface)] transition"
+          appearance="outline"
+          size="sm"
+          className="text-[var(--fg)]"
         >
           Cancel
-        </button>
-        <Button type="submit" glowOnHover innerClassName="font-semibold">
+        </Button>
+        <Button type="submit" glowOnHover className="font-semibold">
           <Save className="w-4 h-4" />
           {mode === 'create' ? 'Add Team Member' : 'Save Changes'}
         </Button>
@@ -771,14 +777,16 @@ const ToolForm: React.FC<ToolFormProps> = ({ mode, initialData, clients, project
       </Section>
 
       <div className="flex items-center justify-end gap-3">
-        <button
+        <Button
           type="button"
           onClick={onCancel}
-          className="px-4 py-2 rounded-lg border border-[var(--border)] text-[var(--fg)] hover:bg-[var(--surface)] transition"
+          appearance="outline"
+          size="sm"
+          className="text-[var(--fg)]"
         >
           Cancel
-        </button>
-        <Button type="submit" glowOnHover innerClassName="font-semibold">
+        </Button>
+        <Button type="submit" glowOnHover className="font-semibold">
           <Sparkles className="w-4 h-4" />
           {mode === 'create' ? 'Create Tool' : 'Save Changes'}
         </Button>

--- a/src/components/Tools/ToolDetails.tsx
+++ b/src/components/Tools/ToolDetails.tsx
@@ -7,6 +7,7 @@ import { useProjects } from '../../hooks/useProjects';
 import TeamMemberModal from '../Clients/TeamMemberModal';
 import ClientModal from '../Projects/ClientModal';
 import ProjectModal from '../Projects/ProjectModal';
+import { Button } from '../Shared/Button';
 
 interface ToolDetailsProps {
   tool: Tool;
@@ -192,18 +193,32 @@ const ToolDetails: React.FC<ToolDetailsProps> = ({ tool, onBack }) => {
           <div className="bg-glass-gradient-light dark:bg-glass-gradient-dark border border-glass-border-light dark:border-glass-border-dark rounded-xl p-6 backdrop-blur-md shadow-lg">
             <h3 className="text-lg font-semibold text-gray-900 dark:text-white mb-4">Quick Actions</h3>
             <div className="space-y-3">
-              <button className="w-full bg-sunset-orange text-white font-semibold py-2 px-4 rounded-lg hover:opacity-90 transition-opacity flex items-center justify-center space-x-2">
+              <Button
+                glowOnHover
+                wrapperClassName="w-full"
+                className="w-full justify-center font-semibold text-white group-hover:text-white group-focus-within:text-white"
+              >
                 <Settings className="w-4 h-4" />
                 <span>Configure Tool</span>
-              </button>
-              <button className="w-full bg-white/30 dark:bg-white/10 text-gray-900 dark:text-white font-semibold py-2 px-4 rounded-lg hover:bg-white/40 dark:hover:bg-white/15 transition-colors backdrop-blur-sm flex items-center justify-center space-x-2">
+              </Button>
+              <Button
+                variant="secondary"
+                appearance="solid"
+                wrapperClassName="w-full"
+                className="w-full justify-center font-semibold border-transparent bg-white/30 text-gray-900 hover:bg-white/40 dark:bg-white/10 dark:text-white dark:hover:bg-white/15 backdrop-blur-sm"
+              >
                 <ExternalLink className="w-4 h-4" />
                 <span>View Logs</span>
-              </button>
-              <button className="w-full bg-white/30 dark:bg-white/10 text-gray-900 dark:text-white font-semibold py-2 px-4 rounded-lg hover:bg-white/40 dark:hover:bg-white/15 transition-colors backdrop-blur-sm flex items-center justify-center space-x-2">
+              </Button>
+              <Button
+                variant="secondary"
+                appearance="solid"
+                wrapperClassName="w-full"
+                className="w-full justify-center font-semibold border-transparent bg-white/30 text-gray-900 hover:bg-white/40 dark:bg-white/10 dark:text-white dark:hover:bg-white/15 backdrop-blur-sm"
+              >
                 <BarChart3 className="w-4 h-4" />
                 <span>Analytics</span>
-              </button>
+              </Button>
             </div>
           </div>
 

--- a/src/views/Clients.tsx
+++ b/src/views/Clients.tsx
@@ -5,10 +5,31 @@ import ClientDetails from '../components/Clients/ClientDetails';
 import { useClients } from '../hooks/useClients';
 import { Client } from '../types';
 import { Button } from '../components/Shared/Button';
+import {
+  EntityFormModal,
+  EntityFormValues,
+  ClientFormValues,
+} from '../components/Shared/EntityFormModal';
 
 const Clients: React.FC = () => {
-  const { clients, isLoading } = useClients();
+  const { clients, isLoading, createClient } = useClients();
   const [selectedClient, setSelectedClient] = useState<Client | null>(null);
+  const [isClientModalOpen, setIsClientModalOpen] = useState(false);
+
+  const handleClientSubmit = (values: EntityFormValues) => {
+    const payload = values as ClientFormValues;
+
+    createClient({
+      companyName: payload.companyName,
+      industry: payload.industry,
+      location: payload.location,
+      status: payload.status,
+      website: payload.website,
+      linkedinUrl: payload.linkedinUrl,
+    });
+
+    setIsClientModalOpen(false);
+  };
 
   if (selectedClient) {
     return <ClientDetails client={selectedClient} onBack={() => setSelectedClient(null)} />;
@@ -27,7 +48,11 @@ const Clients: React.FC = () => {
       <div className="flex justify-between items-center">
         <div>
         </div>
-        <Button glowOnHover className="font-semibold text-white group-hover:text-white group-focus-within:text-white">
+        <Button
+          glowOnHover
+          className="font-semibold text-white group-hover:text-white group-focus-within:text-white"
+          onClick={() => setIsClientModalOpen(true)}
+        >
           <Plus className="w-5 h-5" />
           <span>New Client</span>
         </Button>
@@ -50,12 +75,22 @@ const Clients: React.FC = () => {
             glowOnHover
             wrapperClassName="mx-auto w-full max-w-xs"
             className="w-full justify-center font-semibold"
+            onClick={() => setIsClientModalOpen(true)}
           >
             <Plus className="w-5 h-5" />
             <span>Add Your First Client</span>
           </Button>
         </div>
       )}
+
+      <EntityFormModal
+        isOpen={isClientModalOpen}
+        type="client"
+        mode="create"
+        onClose={() => setIsClientModalOpen(false)}
+        onSubmit={handleClientSubmit}
+        clients={clients}
+      />
     </div>
   );
 };

--- a/src/views/Clients.tsx
+++ b/src/views/Clients.tsx
@@ -4,6 +4,7 @@ import ClientCard from '../components/Clients/ClientCard';
 import ClientDetails from '../components/Clients/ClientDetails';
 import { useClients } from '../hooks/useClients';
 import { Client } from '../types';
+import { Button } from '../components/Shared/Button';
 
 const Clients: React.FC = () => {
   const { clients, isLoading } = useClients();
@@ -26,10 +27,10 @@ const Clients: React.FC = () => {
       <div className="flex justify-between items-center">
         <div>
         </div>
-        <button className="bg-sunset-orange text-white font-semibold py-2 px-4 rounded-lg hover:opacity-90 transition-opacity flex items-center space-x-2">
+        <Button glowOnHover className="font-semibold text-white group-hover:text-white group-focus-within:text-white">
           <Plus className="w-5 h-5" />
           <span>New Client</span>
-        </button>
+        </Button>
       </div>
 
       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
@@ -45,10 +46,14 @@ const Clients: React.FC = () => {
       {clients.length === 0 && (
         <div className="text-center py-12">
           <div className="text-gray-400 mb-4">No clients found</div>
-          <button className="bg-sunset-orange text-white font-semibold py-2 px-4 rounded-lg hover:opacity-90 transition-opacity flex items-center space-x-2 mx-auto">
+          <Button
+            glowOnHover
+            wrapperClassName="mx-auto w-full max-w-xs"
+            className="w-full justify-center font-semibold"
+          >
             <Plus className="w-5 h-5" />
             <span>Add Your First Client</span>
-          </button>
+          </Button>
         </div>
       )}
     </div>

--- a/src/views/Dashboard.tsx
+++ b/src/views/Dashboard.tsx
@@ -2,6 +2,7 @@ import React, { useMemo, useState } from 'react';
 import { Edit, Users, FolderOpen, Wrench, TrendingUp, Activity, DollarSign, Clock, CheckCircle2, ArrowUp, ArrowDown, X } from 'lucide-react';
 import StatsCard from '../components/Dashboard/StatsCard';
 import { Card } from '../components/Shared/Card';
+import { Button } from '../components/Shared/Button';
 import { useAuth } from '../hooks/useAuth';
 
 const availableWidgets = [
@@ -125,13 +126,10 @@ const Dashboard: React.FC = () => {
             {account ? `${account.name} · Performance snapshot` : 'Performance snapshot'}
           </p>
         </div>
-        <button
-          onClick={openCustomize}
-          className="flex items-center gap-2 rounded-lg bg-gradient-to-r from-[var(--accent-orange)] via-[var(--accent-pink)] to-[var(--accent-purple)] px-4 py-2 text-sm font-semibold text-white shadow-sm"
-        >
+        <Button onClick={openCustomize} glowOnHover innerClassName="font-semibold">
           <Edit className="w-4 h-4" />
           Customize
-        </button>
+        </Button>
       </div>
 
       <div className="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-4">
@@ -294,14 +292,15 @@ const Dashboard: React.FC = () => {
                 >
                   Cancel
                 </button>
-                <button
+                <Button
                   type="button"
                   onClick={saveCustomization}
                   disabled={disableSave}
-                  className="rounded-lg bg-gradient-to-r from-[var(--accent-orange)] via-[var(--accent-pink)] to-[var(--accent-purple)] px-4 py-2 text-sm font-semibold text-white disabled:opacity-50"
+                  glowOnHover
+                  innerClassName="font-semibold"
                 >
                   Save layout
-                </button>
+                </Button>
               </div>
             </div>
           </div>

--- a/src/views/Dashboard.tsx
+++ b/src/views/Dashboard.tsx
@@ -126,7 +126,7 @@ const Dashboard: React.FC = () => {
             {account ? `${account.name} · Performance snapshot` : 'Performance snapshot'}
           </p>
         </div>
-        <Button onClick={openCustomize} glowOnHover innerClassName="font-semibold">
+        <Button onClick={openCustomize} glowOnHover className="font-semibold">
           <Edit className="w-4 h-4" />
           Customize
         </Button>
@@ -199,15 +199,17 @@ const Dashboard: React.FC = () => {
         <h3 className="text-lg font-semibold text-[var(--fg)] mb-4">Quick Actions</h3>
         <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
           {[{ title: 'New Project', description: 'Kick off a fresh automation initiative.', icon: FolderOpen, accent: 'text-sky-600 dark:text-sky-300' }, { title: 'Add Team Member', description: 'Invite a collaborator or contractor.', icon: Users, accent: 'text-emerald-600 dark:text-emerald-300' }, { title: 'Deploy Tool', description: 'Launch a new agent or workflow.', icon: Wrench, accent: 'text-purple-600 dark:text-purple-300' }, { title: 'Schedule Review', description: 'Book a client strategy session.', icon: CheckCircle2, accent: 'text-orange-600 dark:text-orange-300' }].map((action) => (
-            <button
+            <Button
               key={action.title}
-              type="button"
-              className="rounded-lg border border-[var(--border)] bg-[var(--surface)]/60 px-4 py-3 text-left transition hover:-translate-y-0.5 hover:shadow-sm"
+              appearance="solid"
+              wrapperClassName="w-full"
+              className="w-full flex-col items-start px-4 py-3 text-left transition-transform hover:-translate-y-0.5 hover:shadow-sm"
+              glowOnHover
             >
               <action.icon className={`mb-2 h-5 w-5 ${action.accent}`} />
               <p className="text-sm font-semibold text-[var(--fg)]">{action.title}</p>
               <p className="text-xs text-[var(--fg-muted)]">{action.description}</p>
-            </button>
+            </Button>
           ))}
         </div>
       </Card>
@@ -285,19 +287,21 @@ const Dashboard: React.FC = () => {
                 Reset to default
               </button>
               <div className="flex items-center gap-3">
-                <button
+                <Button
                   type="button"
                   onClick={() => setIsCustomizeOpen(false)}
-                  className="rounded-lg border border-[var(--border)] px-4 py-2 text-sm text-[var(--fg)] hover:bg-[var(--surface)]"
+                  appearance="outline"
+                  size="sm"
+                  className="text-sm"
                 >
                   Cancel
-                </button>
+                </Button>
                 <Button
                   type="button"
                   onClick={saveCustomization}
                   disabled={disableSave}
                   glowOnHover
-                  innerClassName="font-semibold"
+                  className="font-semibold"
                 >
                   Save layout
                 </Button>

--- a/src/views/Projects.tsx
+++ b/src/views/Projects.tsx
@@ -4,6 +4,7 @@ import ProjectCard from '../components/Projects/ProjectCard';
 import ProjectModal from '../components/Projects/ProjectModal';
 import { useProjects } from '../hooks/useProjects';
 import { Project } from '../types';
+import { Button } from '../components/Shared/Button';
 
 const Projects: React.FC = () => {
   const { projects, isLoading } = useProjects();
@@ -22,10 +23,10 @@ const Projects: React.FC = () => {
       <div className="flex justify-between items-center">
         <div>
         </div>
-        <button className="bg-sunset-orange text-white font-semibold py-2 px-4 rounded-lg hover:opacity-90 transition-opacity flex items-center space-x-2">
+        <Button glowOnHover className="font-semibold text-white group-hover:text-white group-focus-within:text-white">
           <Plus className="w-5 h-5" />
           <span>New Project</span>
-        </button>
+        </Button>
       </div>
 
       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
@@ -41,10 +42,14 @@ const Projects: React.FC = () => {
       {projects.length === 0 && (
         <div className="text-center py-12">
           <div className="text-gray-400 mb-4">No projects found</div>
-          <button className="bg-sunset-orange text-white font-semibold py-2 px-4 rounded-lg hover:opacity-90 transition-opacity flex items-center space-x-2 mx-auto">
+          <Button
+            glowOnHover
+            wrapperClassName="mx-auto w-full max-w-xs"
+            className="w-full justify-center font-semibold"
+          >
             <Plus className="w-5 h-5" />
             <span>Create Your First Project</span>
-          </button>
+          </Button>
         </div>
       )}
 

--- a/src/views/Solutions.tsx
+++ b/src/views/Solutions.tsx
@@ -6,6 +6,7 @@ import { useClients } from '../hooks/useClients';
 import { useTeam } from '../hooks/useTeam';
 import SolutionCard, { SolutionCardData } from '../components/Solutions/SolutionCard';
 import { EntityFormModal, ToolFormValues } from '../components/Shared/EntityFormModal';
+import { Button } from '../components/Shared/Button';
 import { Tool } from '../types/tools';
 
 const solutionTypes = ['tool', 'system', 'template', 'marketplace'] as const;
@@ -506,18 +507,16 @@ const Solutions: React.FC = () => {
               {solutionTypes.map((type) => {
                 const isActive = activeTypes.includes(type);
                 return (
-                  <button
+                  <Button
                     key={type}
-                    type="button"
+                    size="sm"
+                    glowOnHover
+                    activeGlow={isActive}
                     onClick={() => toggleType(type)}
-                    className={`rounded-lg border px-3 py-2 text-sm font-medium transition ${
-                      isActive
-                        ? 'border-transparent bg-gradient-to-r from-[var(--accent-orange)] via-[var(--accent-pink)] to-[var(--accent-purple)] text-white'
-                        : 'border-[var(--border)] bg-[var(--surface)] text-[var(--fg-muted)] hover:text-[var(--fg)]'
-                    }`}
+                    innerClassName={`px-3 py-2 text-sm font-medium ${isActive ? 'text-[var(--fg)]' : 'text-[var(--fg-muted)]'}`}
                   >
                     {typeLabels[type]}
-                  </button>
+                  </Button>
                 );
               })}
             </div>
@@ -539,14 +538,14 @@ const Solutions: React.FC = () => {
                 </select>
               </div>
 
-              <button
-                type="button"
+              <Button
                 onClick={() => setToolFormState({ mode: 'create' })}
-                className="flex items-center gap-2 rounded-lg bg-gradient-to-r from-[var(--accent-orange)] via-[var(--accent-pink)] to-[var(--accent-purple)] px-4 py-2 text-sm font-semibold text-white shadow-sm"
+                glowOnHover
+                innerClassName="font-semibold"
               >
                 <PlusCircle className="h-4 w-4" />
                 Add Tool
-              </button>
+              </Button>
             </div>
           </div>
         </div>
@@ -655,12 +654,9 @@ const Solutions: React.FC = () => {
               </div>
             </div>
 
-            <button
-              type="submit"
-              className="flex items-center gap-2 rounded-lg bg-gradient-to-r from-[var(--accent-orange)] via-[var(--accent-pink)] to-[var(--accent-purple)] px-4 py-2 text-sm font-semibold text-white"
-            >
+            <Button type="submit" glowOnHover innerClassName="font-semibold">
               Save Metrics
-            </button>
+            </Button>
           </form>
         </div>
 

--- a/src/views/Solutions.tsx
+++ b/src/views/Solutions.tsx
@@ -513,7 +513,7 @@ const Solutions: React.FC = () => {
                     glowOnHover
                     activeGlow={isActive}
                     onClick={() => toggleType(type)}
-                    innerClassName={`px-3 py-2 text-sm font-medium ${isActive ? 'text-[var(--fg)]' : 'text-[var(--fg-muted)]'}`}
+                    className={`px-3 py-2 text-sm font-medium ${isActive ? 'text-[var(--fg)]' : 'text-[var(--fg-muted)]'}`}
                   >
                     {typeLabels[type]}
                   </Button>
@@ -541,7 +541,7 @@ const Solutions: React.FC = () => {
               <Button
                 onClick={() => setToolFormState({ mode: 'create' })}
                 glowOnHover
-                innerClassName="font-semibold"
+                className="font-semibold"
               >
                 <PlusCircle className="h-4 w-4" />
                 Add Tool
@@ -654,7 +654,7 @@ const Solutions: React.FC = () => {
               </div>
             </div>
 
-            <Button type="submit" glowOnHover innerClassName="font-semibold">
+            <Button type="submit" glowOnHover className="font-semibold">
               Save Metrics
             </Button>
           </form>

--- a/src/views/Team.tsx
+++ b/src/views/Team.tsx
@@ -3,6 +3,7 @@ import { Plus, Users, Mail, Phone, MapPin, BarChart3, User } from 'lucide-react'
 import { useTeam } from '../hooks/useTeam';
 import TeamMemberModal from '../components/Clients/TeamMemberModal';
 import { Card } from '../components/Shared/Card';
+import { Button } from '../components/Shared/Button';
 
 const Team: React.FC = () => {
   const { teamMembers, isLoading } = useTeam();
@@ -30,10 +31,10 @@ const Team: React.FC = () => {
           <h1 className="text-2xl font-bold text-[var(--fg)]">Team</h1>
           <p className="text-[var(--fg-muted)]">Manage your team members and track their performance</p>
         </div>
-        <button className="bg-sunset-orange text-white font-semibold py-2 px-4 rounded-lg hover:opacity-90 transition-opacity flex items-center space-x-2">
+        <Button glowOnHover className="font-semibold text-white group-hover:text-white group-focus-within:text-white">
           <Plus className="w-5 h-5" />
           <span>Add Team Member</span>
-        </button>
+        </Button>
       </div>
 
       {/* Team Stats */}
@@ -175,10 +176,14 @@ const Team: React.FC = () => {
       {teamMembers.length === 0 && (
         <div className="text-center py-12">
           <div className="text-[var(--fg-muted)] mb-4">No team members found</div>
-          <button className="bg-sunset-orange text-white font-semibold py-2 px-4 rounded-lg hover:opacity-90 transition-opacity flex items-center space-x-2 mx-auto">
+          <Button
+            glowOnHover
+            wrapperClassName="mx-auto w-full max-w-xs"
+            className="w-full justify-center font-semibold"
+          >
             <Plus className="w-5 h-5" />
             <span>Add Your First Team Member</span>
-          </button>
+          </Button>
         </div>
       )}
 

--- a/src/views/Tools.tsx
+++ b/src/views/Tools.tsx
@@ -4,6 +4,7 @@ import ToolCard from '../components/Tools/ToolCard';
 import ToolDetails from '../components/Tools/ToolDetails';
 import { useTools } from '../hooks/useTools';
 import { Tool } from '../types/tools';
+import { Button } from '../components/Shared/Button';
 
 const Tools: React.FC = () => {
   const { tools, isLoading } = useTools();
@@ -26,10 +27,10 @@ const Tools: React.FC = () => {
       <div className="flex justify-between items-center">
         <div>
         </div>
-        <button className="bg-sunset-orange text-white font-semibold py-2 px-4 rounded-lg hover:opacity-90 transition-opacity flex items-center space-x-2">
+        <Button glowOnHover className="font-semibold text-white group-hover:text-white group-focus-within:text-white">
           <Plus className="w-5 h-5" />
           <span>New Tool</span>
-        </button>
+        </Button>
       </div>
 
       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
@@ -45,10 +46,14 @@ const Tools: React.FC = () => {
       {tools.length === 0 && (
         <div className="text-center py-12">
           <div className="text-gray-400 mb-4">No tools found</div>
-          <button className="bg-sunset-orange text-white font-semibold py-2 px-4 rounded-lg hover:opacity-90 transition-opacity flex items-center space-x-2 mx-auto">
+          <Button
+            glowOnHover
+            wrapperClassName="mx-auto w-full max-w-xs"
+            className="w-full justify-center font-semibold"
+          >
             <Plus className="w-5 h-5" />
             <span>Create Your First Tool</span>
-          </button>
+          </Button>
         </div>
       )}
     </div>

--- a/src/views/Workspaces.tsx
+++ b/src/views/Workspaces.tsx
@@ -6,6 +6,7 @@ import { useTeam } from '../hooks/useTeam';
 import { useAuth } from '../hooks/useAuth';
 import WorkspaceCard, { WorkspaceCardData } from '../components/Workspaces/WorkspaceCard';
 import { EntityFormModal, EntityFormValues, ClientFormValues, ProjectFormValues, TeamFormValues } from '../components/Shared/EntityFormModal';
+import { Button } from '../components/Shared/Button';
 import { Client, Project, TeamMember } from '../types';
 
 const typeOrder = ['client', 'project', 'team'] as const;
@@ -255,18 +256,16 @@ const Workspaces: React.FC = () => {
               {typeOrder.map((type) => {
                 const isActive = activeTypes.includes(type);
                 return (
-                  <button
+                  <Button
                     key={type}
-                    type="button"
+                    size="sm"
+                    glowOnHover
+                    activeGlow={isActive}
                     onClick={() => toggleType(type)}
-                    className={`rounded-lg border px-3 py-2 text-sm font-medium transition ${
-                      isActive
-                        ? 'border-transparent bg-gradient-to-r from-[var(--accent-orange)] via-[var(--accent-pink)] to-[var(--accent-purple)] text-white'
-                        : 'border-[var(--border)] bg-[var(--surface)] text-[var(--fg-muted)] hover:text-[var(--fg)]'
-                    }`}
+                    innerClassName={`px-3 py-2 text-sm font-medium ${isActive ? 'text-[var(--fg)]' : 'text-[var(--fg-muted)]'}`}
                   >
                     {typeLabels[type]}
-                  </button>
+                  </Button>
                 );
               })}
             </div>
@@ -300,14 +299,14 @@ const Workspaces: React.FC = () => {
                     </option>
                   ))}
                 </select>
-                <button
-                  type="button"
+                <Button
                   onClick={() => setFormState({ type: createType, mode: 'create' })}
-                  className="flex items-center gap-2 rounded-lg bg-gradient-to-r from-[var(--accent-orange)] via-[var(--accent-pink)] to-[var(--accent-purple)] px-4 py-2 text-sm font-semibold text-white shadow-sm"
+                  glowOnHover
+                  innerClassName="font-semibold"
                 >
                   <PlusCircle className="h-4 w-4" />
                   Add {typeLabels[createType]}
-                </button>
+                </Button>
               </div>
             </div>
           </div>

--- a/src/views/Workspaces.tsx
+++ b/src/views/Workspaces.tsx
@@ -262,7 +262,7 @@ const Workspaces: React.FC = () => {
                     glowOnHover
                     activeGlow={isActive}
                     onClick={() => toggleType(type)}
-                    innerClassName={`px-3 py-2 text-sm font-medium ${isActive ? 'text-[var(--fg)]' : 'text-[var(--fg-muted)]'}`}
+                    className={`px-3 py-2 text-sm font-medium ${isActive ? 'text-[var(--fg)]' : 'text-[var(--fg-muted)]'}`}
                   >
                     {typeLabels[type]}
                   </Button>
@@ -302,7 +302,7 @@ const Workspaces: React.FC = () => {
                 <Button
                   onClick={() => setFormState({ type: createType, mode: 'create' })}
                   glowOnHover
-                  innerClassName="font-semibold"
+                  className="font-semibold"
                 >
                   <PlusCircle className="h-4 w-4" />
                   Add {typeLabels[createType]}


### PR DESCRIPTION
## Summary
- update the shared Button to default to the gradient glow treatment while adding solid/outline fallbacks for other contexts
- refactor major views and modals to reuse the shared Button instead of inline gradient classes for actions
- tighten global spacing by shrinking the header/logo, reducing main padding, and locking the sidebar layout

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d0554fc9d0832d96ed5a9a145f439a