### PR TITLE
Add client metrics filtering and improve card layout

### DIFF
--- a/src/components/Clients/ClientCard.tsx
+++ b/src/components/Clients/ClientCard.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Building2, MapPin, Users, ExternalLink } from 'lucide-react';
+import { Building2, ExternalLink, MapPin, Users } from 'lucide-react';
 import { Client } from '../../types';
 import { Card } from '../Shared/Card';
 
@@ -8,10 +8,10 @@ interface ClientCardProps {
   onClick: () => void;
 }
 
-const statusColors = {
+const statusColors: Record<Client['status'], string> = {
   active: 'bg-green-500/20 text-green-400 border-green-500/30',
   inactive: 'bg-gray-500/20 text-gray-400 border-gray-500/30',
-  prospect: 'bg-yellow-500/20 text-yellow-400 border-yellow-500/30',
+  prospect: 'bg-yellow-500/20 text-yellow-400 border-yellow-500/30'
 };
 
 const ClientCard: React.FC<ClientCardProps> = ({ client, onClick }) => {
@@ -19,47 +19,55 @@ const ClientCard: React.FC<ClientCardProps> = ({ client, onClick }) => {
     <Card
       glowOnHover={true}
       onClick={onClick}
-      className="p-6 group"
+      className="group flex h-full flex-col p-6"
     >
-      <div className="flex items-start justify-between mb-4">
-        <div className="flex items-center space-x-3">
-          <div className="w-12 h-12 bg-gradient-primary rounded-lg flex items-center justify-center">
-            <Building2 className="w-6 h-6 text-white" />
+      <div className="flex flex-col gap-4">
+        <div className="flex items-start justify-between gap-3">
+          <div className="flex min-w-0 items-start gap-3">
+            <div className="flex h-12 w-12 flex-shrink-0 items-center justify-center rounded-lg bg-gradient-primary">
+              <Building2 className="w-6 h-6 text-white" />
+            </div>
+            <div className="min-w-0">
+              <h3 className="break-words text-lg font-semibold leading-tight text-gray-900 transition-colors group-hover:text-gradient-orange dark:text-white">
+                {client.companyName}
+              </h3>
+              <p className="mt-1 break-words text-sm text-[var(--fg-muted)]">{client.industry}</p>
+            </div>
           </div>
-          <div>
-            <h3 className="text-xl font-semibold text-gray-900 dark:text-white group-hover:text-gradient-orange transition-colors">
-              {client.companyName}
-            </h3>
-            <p className="text-sm text-[var(--fg-muted)]">{client.industry}</p>
-          </div>
+          <span className={`flex-shrink-0 rounded-full border px-3 py-1 text-xs font-medium ${statusColors[client.status]}`}>
+            {client.status.charAt(0).toUpperCase() + client.status.slice(1)}
+          </span>
         </div>
-        <span className={`px-3 py-1 rounded-full text-xs font-medium border ${statusColors[client.status]}`}>
-          {client.status.charAt(0).toUpperCase() + client.status.slice(1)}
-        </span>
+
+        <div className="space-y-3">
+          <div className="flex items-start gap-2 text-sm text-[var(--fg-muted)]">
+            <MapPin className="mt-0.5 h-4 w-4 flex-shrink-0" />
+            <span className="text-[var(--fg)] break-words">{client.location}</span>
+          </div>
+
+          <div className="flex items-start gap-2 text-sm text-[var(--fg-muted)]">
+            <Users className="mt-0.5 h-4 w-4 flex-shrink-0" />
+            <span className="text-[var(--fg)]">
+              {client.contacts.length} contact{client.contacts.length !== 1 ? 's' : ''}
+            </span>
+          </div>
+
+          {client.website && (
+            <div className="flex items-start gap-2 text-sm text-[var(--fg-muted)]">
+              <ExternalLink className="mt-0.5 h-4 w-4 flex-shrink-0" />
+              <span className="text-[var(--fg)] break-words">
+                {client.website.replace('https://', '').replace('http://', '')}
+              </span>
+            </div>
+          )}
+        </div>
       </div>
 
-      <div className="space-y-3">
-        <div className="flex items-center space-x-2 text-sm text-[var(--fg-muted)]">
-          <MapPin className="w-4 h-4" />
-          <span className="text-[var(--fg)]">{client.location}</span>
-        </div>
-
-        <div className="flex items-center space-x-2 text-sm text-[var(--fg-muted)]">
-          <Users className="w-4 h-4" />
-          <span className="text-[var(--fg)]">{client.contacts.length} contact{client.contacts.length !== 1 ? 's' : ''}</span>
-        </div>
-
-        {client.website && (
-          <div className="flex items-center space-x-2 text-sm text-[var(--fg-muted)]">
-            <ExternalLink className="w-4 h-4" />
-            <span className="truncate text-[var(--fg)]">{client.website.replace('https://', '')}</span>
-          </div>
-        )}
-      </div>
-
-      <div className="mt-4 pt-4 border-t border-[var(--border)]">
-        <div className="flex items-center justify-between text-sm text-[var(--fg-muted)]">
-          <span className="text-[var(--fg)]">{client.projectIds.length} active project{client.projectIds.length !== 1 ? 's' : ''}</span>
+      <div className="mt-6 border-t border-[var(--border)] pt-4">
+        <div className="flex flex-col gap-2 text-sm text-[var(--fg-muted)] sm:flex-row sm:items-center sm:justify-between">
+          <span className="text-[var(--fg)]">
+            {client.projectIds.length} active project{client.projectIds.length !== 1 ? 's' : ''}
+          </span>
           <span className="text-[var(--fg-muted)]">Updated {new Date(client.updatedAt).toLocaleDateString()}</span>
         </div>
       </div>

--- a/src/utils/timeRanges.ts
+++ b/src/utils/timeRanges.ts
@@ -1,0 +1,79 @@
+export type TimeRangeKey = '7d' | '30d' | '90d' | 'ytd' | 'all';
+
+export interface TimeRangeOption {
+  value: TimeRangeKey;
+  label: string;
+  shortLabel: string;
+  getStartDate: () => Date | null;
+}
+
+const createRelativeStartDate = (days: number): Date => {
+  const date = new Date();
+  date.setHours(0, 0, 0, 0);
+  // Include the current day in the range by subtracting days - 1
+  date.setDate(date.getDate() - (days - 1));
+  return date;
+};
+
+const createYearToDateStart = (): Date => {
+  const date = new Date();
+  date.setHours(0, 0, 0, 0);
+  date.setMonth(0, 1);
+  return date;
+};
+
+export const timeRangeOptions: TimeRangeOption[] = [
+  {
+    value: '7d',
+    label: 'Last 7 days',
+    shortLabel: '7 days',
+    getStartDate: () => createRelativeStartDate(7)
+  },
+  {
+    value: '30d',
+    label: 'Last 30 days',
+    shortLabel: '30 days',
+    getStartDate: () => createRelativeStartDate(30)
+  },
+  {
+    value: '90d',
+    label: 'Last 90 days',
+    shortLabel: '90 days',
+    getStartDate: () => createRelativeStartDate(90)
+  },
+  {
+    value: 'ytd',
+    label: 'Year to date',
+    shortLabel: 'YTD',
+    getStartDate: createYearToDateStart
+  },
+  {
+    value: 'all',
+    label: 'All time',
+    shortLabel: 'All time',
+    getStartDate: () => null
+  }
+];
+
+export const DEFAULT_TIME_RANGE: TimeRangeKey = '30d';
+
+export const getTimeRangeStart = (value: TimeRangeKey): Date | null => {
+  const option = timeRangeOptions.find((item) => item.value === value);
+  return option ? option.getStartDate() : null;
+};
+
+export const isWithinTimeRange = (
+  input: string | number | Date,
+  start: Date | null
+): boolean => {
+  if (!start) {
+    return true;
+  }
+
+  const value = input instanceof Date ? input : new Date(input);
+  if (Number.isNaN(value.getTime())) {
+    return false;
+  }
+
+  return value >= start;
+};

--- a/src/views/Clients.tsx
+++ b/src/views/Clients.tsx
@@ -1,13 +1,141 @@
-import React, { useState } from 'react';
-import { Plus } from 'lucide-react';
+import React, { useMemo, useState } from 'react';
+import { CalendarRange, ChevronDown, Plus, Search } from 'lucide-react';
 import ClientCard from '../components/Clients/ClientCard';
 import ClientDetails from '../components/Clients/ClientDetails';
 import { useClients } from '../hooks/useClients';
 import { Client } from '../types';
+import {
+  DEFAULT_TIME_RANGE,
+  TimeRangeKey,
+  getTimeRangeStart,
+  isWithinTimeRange,
+  timeRangeOptions
+} from '../utils/timeRanges';
+
+type MetricFilter = 'total' | 'active' | 'prospect' | 'new';
+
+interface MetricDefinition {
+  key: MetricFilter;
+  label: string;
+  description: string;
+  value: number;
+}
 
 const Clients: React.FC = () => {
   const { clients, isLoading } = useClients();
   const [selectedClient, setSelectedClient] = useState<Client | null>(null);
+  const [searchTerm, setSearchTerm] = useState('');
+  const [selectedMetric, setSelectedMetric] = useState<MetricFilter>('total');
+  const [timeRange, setTimeRange] = useState<TimeRangeKey>(DEFAULT_TIME_RANGE);
+
+  const rangeStart = useMemo(() => getTimeRangeStart(timeRange), [timeRange]);
+
+  const selectedRangeOption = useMemo(() => {
+    return (
+      timeRangeOptions.find((option) => option.value === timeRange) ?? timeRangeOptions[0]
+    );
+  }, [timeRange]);
+
+  const metricCounts = useMemo(() => {
+    let active = 0;
+    let prospects = 0;
+    let newClients = 0;
+
+    clients.forEach((client) => {
+      if (client.status === 'active') {
+        active += 1;
+      }
+
+      if (client.status === 'prospect') {
+        prospects += 1;
+      }
+
+      if (isWithinTimeRange(client.createdAt, rangeStart)) {
+        newClients += 1;
+      }
+    });
+
+    return {
+      total: clients.length,
+      active,
+      prospects,
+      new: newClients
+    };
+  }, [clients, rangeStart]);
+
+  const metrics = useMemo<MetricDefinition[]>(() => {
+    return [
+      {
+        key: 'total',
+        label: 'Total',
+        description: 'All clients',
+        value: metricCounts.total
+      },
+      {
+        key: 'active',
+        label: 'Active',
+        description: 'Active partnerships',
+        value: metricCounts.active
+      },
+      {
+        key: 'prospect',
+        label: 'Prospects',
+        description: 'Sales pipeline',
+        value: metricCounts.prospects
+      },
+      {
+        key: 'new',
+        label: 'New',
+        description: selectedRangeOption.label,
+        value: metricCounts.new
+      }
+    ];
+  }, [metricCounts, selectedRangeOption]);
+
+  const filteredClients = useMemo(() => {
+    const normalizedSearch = searchTerm.trim().toLowerCase();
+
+    return clients.filter((client) => {
+      const matchesSearch =
+        normalizedSearch.length === 0 ||
+        [
+          client.companyName,
+          client.industry,
+          client.location,
+          client.status,
+          client.website ?? '',
+          client.linkedinUrl ?? ''
+        ].some((value) => value.toLowerCase().includes(normalizedSearch)) ||
+        client.contacts.some((contact) =>
+          [contact.name, contact.title, contact.email ?? '']
+            .map((value) => value.toLowerCase())
+            .some((value) => value.includes(normalizedSearch))
+        );
+
+      if (!matchesSearch) {
+        return false;
+      }
+
+      switch (selectedMetric) {
+        case 'total':
+          return true;
+        case 'active':
+          return client.status === 'active';
+        case 'prospect':
+          return client.status === 'prospect';
+        case 'new':
+          return isWithinTimeRange(client.createdAt, rangeStart);
+        default:
+          return true;
+      }
+    });
+  }, [clients, rangeStart, searchTerm, selectedMetric]);
+
+  const handleResetFilters = () => {
+    setSearchTerm('');
+    setSelectedMetric('total');
+    setTimeRange(DEFAULT_TIME_RANGE);
+  };
 
   if (selectedClient) {
     return <ClientDetails client={selectedClient} onBack={() => setSelectedClient(null)} />;
@@ -21,34 +149,119 @@ const Clients: React.FC = () => {
     );
   }
 
+  const hasClients = clients.length > 0;
+
   return (
     <div className="space-y-6">
-      <div className="flex justify-between items-center">
-        <div>
+      <div className="space-y-4">
+        <div className="flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
+          <div className="space-y-3">
+            <h1 className="text-2xl font-semibold text-[var(--fg)]">Clients</h1>
+            <p className="text-sm text-[var(--fg-muted)]">
+              Monitor relationships, opportunities, and delivery activity across every account.
+            </p>
+            <div className="relative max-w-md">
+              <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-[var(--fg-muted)]" />
+              <input
+                className="w-full rounded-lg border border-[var(--border)] bg-[var(--surface)] py-2 pl-9 pr-3 text-sm text-[var(--fg)] focus:outline-none focus:ring-2 focus:ring-[var(--accent-purple)]"
+                placeholder="Search clients by name, industry, or location"
+                value={searchTerm}
+                onChange={(event) => setSearchTerm(event.target.value)}
+              />
+            </div>
+          </div>
+
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
+            <div className="relative w-full sm:w-auto">
+              <CalendarRange className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-[var(--fg-muted)]" />
+              <select
+                className="w-full appearance-none rounded-lg border border-[var(--border)] bg-[var(--surface)] py-2 pl-9 pr-10 text-sm text-[var(--fg)] focus:outline-none focus:ring-2 focus:ring-[var(--accent-purple)]"
+                value={timeRange}
+                onChange={(event) => setTimeRange(event.target.value as TimeRangeKey)}
+              >
+                {timeRangeOptions.map((option) => (
+                  <option key={option.value} value={option.value}>
+                    {option.label}
+                  </option>
+                ))}
+              </select>
+              <ChevronDown className="pointer-events-none absolute right-3 top-1/2 h-4 w-4 -translate-y-1/2 text-[var(--fg-muted)]" />
+            </div>
+
+            <button
+              type="button"
+              className="flex items-center justify-center gap-2 rounded-lg bg-sunset-orange px-4 py-2 font-semibold text-white transition-opacity hover:opacity-90"
+            >
+              <Plus className="h-5 w-5" />
+              <span>New Client</span>
+            </button>
+          </div>
         </div>
-        <button className="bg-sunset-orange text-white font-semibold py-2 px-4 rounded-lg hover:opacity-90 transition-opacity flex items-center space-x-2">
-          <Plus className="w-5 h-5" />
-          <span>New Client</span>
-        </button>
+
+        <div className="grid grid-cols-2 gap-3 md:grid-cols-4">
+          {metrics.map((metric) => {
+            const isActive = selectedMetric === metric.key;
+            return (
+              <button
+                key={metric.key}
+                type="button"
+                onClick={() => setSelectedMetric(metric.key)}
+                aria-pressed={isActive}
+                className={`rounded-xl border px-4 py-3 text-left transition focus:outline-none focus:ring-2 focus:ring-[var(--accent-purple)] ${
+                  isActive
+                    ? 'border-transparent bg-gradient-to-r from-[var(--accent-orange)] via-[var(--accent-pink)] to-[var(--accent-purple)] text-white shadow'
+                    : 'border-[var(--border)] bg-[var(--surface)] text-[var(--fg)] hover:border-[var(--accent-orange)]'
+                }`}
+              >
+                <div className="flex items-center justify-between gap-3">
+                  <p className={`text-sm font-medium ${isActive ? 'text-white/90' : 'text-[var(--fg-muted)]'}`}>
+                    {metric.label}
+                  </p>
+                  <p className={`text-2xl font-semibold ${isActive ? 'text-white' : 'text-[var(--fg)]'}`}>
+                    {metric.value}
+                  </p>
+                </div>
+                <p className={`mt-1 text-xs ${isActive ? 'text-white/80' : 'text-[var(--fg-muted)]'}`}>
+                  {metric.description}
+                </p>
+              </button>
+            );
+          })}
+        </div>
       </div>
 
-      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-        {clients.map((client) => (
-          <ClientCard
-            key={client.id}
-            client={client}
-            onClick={() => setSelectedClient(client)}
-          />
-        ))}
-      </div>
-
-      {clients.length === 0 && (
-        <div className="text-center py-12">
-          <div className="text-gray-400 mb-4">No clients found</div>
-          <button className="bg-sunset-orange text-white font-semibold py-2 px-4 rounded-lg hover:opacity-90 transition-opacity flex items-center space-x-2 mx-auto">
-            <Plus className="w-5 h-5" />
-            <span>Add Your First Client</span>
-          </button>
+      {filteredClients.length > 0 ? (
+        <div className="grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-3">
+          {filteredClients.map((client) => (
+            <ClientCard
+              key={client.id}
+              client={client}
+              onClick={() => setSelectedClient(client)}
+            />
+          ))}
+        </div>
+      ) : (
+        <div className="rounded-xl border border-dashed border-[var(--border)] bg-[var(--surface)]/60 py-12 text-center">
+          <p className="mb-4 text-[var(--fg-muted)]">
+            {hasClients ? 'No clients match your filters.' : 'No clients found'}
+          </p>
+          {hasClients ? (
+            <button
+              type="button"
+              onClick={handleResetFilters}
+              className="rounded-lg border border-[var(--border)] bg-transparent px-4 py-2 text-sm font-medium text-[var(--fg)] transition hover:border-[var(--accent-orange)]"
+            >
+              Clear filters
+            </button>
+          ) : (
+            <button
+              type="button"
+              className="mx-auto flex items-center justify-center gap-2 rounded-lg bg-sunset-orange px-4 py-2 font-semibold text-white transition-opacity hover:opacity-90"
+            >
+              <Plus className="h-5 w-5" />
+              <span>Add Your First Client</span>
+            </button>
+          )}
         </div>
       )}
     </div>


### PR DESCRIPTION
## Summary
- add a metric filter bar and time-range selector to the clients view so counts and the grid react to selections
- reuse a shared time-range helper while combining search, metric, and range filters with clear empty states
- refine client card typography and layout so long company details wrap cleanly on compact cards

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d057a460ec832db21e57de195bbf23