### PR TITLE
Enable proposal creation and editing from client details

### DIFF
--- a/src/views/Clients.tsx
+++ b/src/views/Clients.tsx
@@ -3,14 +3,24 @@ import { Plus } from 'lucide-react';
 import ClientCard from '../components/Clients/ClientCard';
 import ClientDetails from '../components/Clients/ClientDetails';
 import { useClients } from '../hooks/useClients';
-import { Client } from '../types';
 
 const Clients: React.FC = () => {
-  const { clients, isLoading } = useClients();
-  const [selectedClient, setSelectedClient] = useState<Client | null>(null);
+  const { clients, isLoading, createProposal, updateProposal } = useClients();
+  const [selectedClientId, setSelectedClientId] = useState<string | null>(null);
 
-  if (selectedClient) {
-    return <ClientDetails client={selectedClient} onBack={() => setSelectedClient(null)} />;
+  const activeClient = selectedClientId
+    ? clients.find(client => client.id === selectedClientId) ?? null
+    : null;
+
+  if (selectedClientId && activeClient) {
+    return (
+      <ClientDetails
+        client={activeClient}
+        onBack={() => setSelectedClientId(null)}
+        onCreateProposal={(proposal) => createProposal(activeClient.id, proposal)}
+        onUpdateProposal={(proposalId, updates) => updateProposal(activeClient.id, proposalId, updates)}
+      />
+    );
   }
 
   if (isLoading) {
@@ -37,7 +47,7 @@ const Clients: React.FC = () => {
           <ClientCard
             key={client.id}
             client={client}
-            onClick={() => setSelectedClient(client)}
+            onClick={() => setSelectedClientId(client.id)}
           />
         ))}
       </div>


### PR DESCRIPTION
## Summary
- add proposal creation and update helpers to the clients hook so state stays in sync
- extend the shared entity modal with a proposal form for capturing value, status, and key dates
- wire the client views to open the proposal modal from the actions area and refresh details immediately after create or edit

## Testing
- npm run lint
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d057b26ec4832da8d6df783be3d815