### PR TITLE
Integrate unified navigation for workspace views

### DIFF
--- a/src/components/Layout/Sidebar.tsx
+++ b/src/components/Layout/Sidebar.tsx
@@ -1,30 +1,23 @@
 import React from 'react';
-import { LayoutDashboard, BarChart3, Users, LogOut, Activity } from 'lucide-react';
+import { LogOut } from 'lucide-react';
+
 import { useAuth } from '../../hooks/useAuth';
-import { getAvailablePages } from '../../utils/permissions';
+import { NAVIGATION_ITEMS } from '../../lib/navigation';
+import type { ViewId } from '../../types/navigation';
 import { Logo } from '../Shared/Logo';
 
 interface SidebarProps {
-  activeView: string;
-  onViewChange: (view: string) => void;
+  activeView: ViewId;
+  availablePages: ViewId[];
+  onViewChange: (view: ViewId) => void;
 }
 
-const Sidebar: React.FC<SidebarProps> = ({ activeView, onViewChange }) => {
+const Sidebar: React.FC<SidebarProps> = ({ activeView, availablePages, onViewChange }) => {
   const { user, account, logout } = useAuth();
 
   if (!user || !account) return null;
 
-  const availablePages = getAvailablePages(user);
-
-  const allMenuItems = [
-    { id: 'dashboard', label: 'Dashboard', icon: LayoutDashboard },
-    { id: 'company', label: 'Company', icon: BarChart3 },
-    { id: 'workspaces', label: 'Workspaces', icon: Users },
-    { id: 'systemsHub', label: 'Systems Hub', icon: Activity },
-    { id: 'analytics', label: 'Analytics', icon: BarChart3 },
-  ];
-
-  const menuItems = allMenuItems.filter(item => availablePages.includes(item.id));
+  const menuItems = NAVIGATION_ITEMS.filter((item) => availablePages.includes(item.id));
 
   return (
     <div className="w-64 bg-[var(--bg-start)] border-r border-[var(--border)] flex flex-col">
@@ -38,7 +31,7 @@ const Sidebar: React.FC<SidebarProps> = ({ activeView, onViewChange }) => {
             const isActive = activeView === item.id;
             return (
               <li key={item.id} className="relative group">
-                <div 
+                <div
                   className={`absolute -inset-0.5 bg-gradient-to-r from-[var(--accent-orange)] via-[var(--accent-pink)] to-[var(--accent-purple)] rounded-lg transition-opacity duration-300 z-0 ${
                     isActive ? 'opacity-75' : 'opacity-0 group-hover:opacity-75'
                   }`}

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -1,5 +1,6 @@
 import React, { createContext, useState, useEffect } from 'react';
 import { User, Account } from '../types';
+import type { ViewId } from '../types/navigation';
 
 interface AuthContextType {
   user: User | null;
@@ -10,6 +11,18 @@ interface AuthContextType {
 }
 
 export const AuthContext = createContext<AuthContextType | undefined>(undefined);
+
+const managerDefaultPages: ViewId[] = [
+  'dashboard',
+  'analytics',
+  'company',
+  'clients',
+  'projects',
+  'team',
+  'workspaces',
+  'tools',
+  'solutions',
+];
 
 // Mock accounts data
 const mockAccounts: Account[] = [
@@ -72,7 +85,7 @@ const mockUsers = {
     role: 'manager' as const,
     accountType: 'agency' as const,
     accountId: 'acc-1',
-    enabledPages: ['dashboard', 'company', 'analytics', 'workspaces', 'systemsHub'],
+    enabledPages: managerDefaultPages,
     createdAt: '2024-01-01T00:00:00Z',
   },
   'employee@demo.com': {

--- a/src/lib/navigation.ts
+++ b/src/lib/navigation.ts
@@ -1,0 +1,27 @@
+import {
+  LayoutDashboard,
+  BarChart3,
+  Building2,
+  Handshake,
+  FolderOpen,
+  Users,
+  PanelsTopLeft,
+  Wrench,
+  Share2,
+} from 'lucide-react';
+
+import type { NavigationItem, ViewId } from '../types/navigation';
+
+export const NAVIGATION_ITEMS: NavigationItem[] = [
+  { id: 'dashboard', label: 'Dashboard', icon: LayoutDashboard },
+  { id: 'analytics', label: 'Analytics', icon: BarChart3 },
+  { id: 'company', label: 'Company', icon: Building2 },
+  { id: 'clients', label: 'Clients', icon: Handshake },
+  { id: 'projects', label: 'Projects', icon: FolderOpen },
+  { id: 'team', label: 'Team', icon: Users },
+  { id: 'workspaces', label: 'Workspaces', icon: PanelsTopLeft },
+  { id: 'tools', label: 'Tools', icon: Wrench },
+  { id: 'solutions', label: 'Solutions Hub', icon: Share2 },
+];
+
+export const DEFAULT_VIEW_ID: ViewId = 'dashboard';

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,3 +1,5 @@
+import type { ViewId } from './navigation';
+
 export interface User {
   id: string;
   email: string;
@@ -6,7 +8,7 @@ export interface User {
   accountType: 'agency' | 'consultant' | 'business';
   accountId: string;
   managerId?: string; // For employees/contractors assigned to managers
-  enabledPages?: string[]; // For managers - pages enabled by owner
+  enabledPages?: ViewId[]; // For managers - pages enabled by owner
   createdAt: string;
 }
 

--- a/src/types/navigation.ts
+++ b/src/types/navigation.ts
@@ -1,0 +1,18 @@
+import type { LucideIcon } from 'lucide-react';
+
+export type ViewId =
+  | 'dashboard'
+  | 'analytics'
+  | 'company'
+  | 'clients'
+  | 'projects'
+  | 'team'
+  | 'workspaces'
+  | 'tools'
+  | 'solutions';
+
+export interface NavigationItem {
+  id: ViewId;
+  label: string;
+  icon: LucideIcon;
+}


### PR DESCRIPTION
## Summary
- add typed view identifiers with a shared navigation configuration
- update the app shell to render the new workspace sections based on available pages
- refresh the sidebar, auth context, and permissions logic to align with the unified navigation

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d05c763f48832dab174da145a078f7