### PR TITLE
Use client id to select client details

### DIFF
--- a/src/views/Clients.tsx
+++ b/src/views/Clients.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { Plus } from 'lucide-react';
 import ClientCard from '../components/Clients/ClientCard';
 import ClientDetails from '../components/Clients/ClientDetails';
@@ -11,6 +11,12 @@ const Clients: React.FC = () => {
   const activeClient = selectedClientId
     ? clients.find(client => client.id === selectedClientId) ?? null
     : null;
+
+  useEffect(() => {
+    if (selectedClientId && !clients.some(client => client.id === selectedClientId)) {
+      setSelectedClientId(null);
+    }
+  }, [clients, selectedClientId]);
 
   if (selectedClientId && activeClient) {
     return (


### PR DESCRIPTION
## Summary
- track the selected client by identifier and derive the active client from the current list
- reset the selected client when it is no longer present so the UI falls back to the list view

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d06b833304832d9c0733019b0c9d2e