### PR TITLE
Create dashboard overview and align navigation

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,9 +7,9 @@ import Header from './components/Layout/Header';
 import Sidebar from './components/Layout/Sidebar';
 import { Footer } from './components/Shared/Footer';
 import Company from './views/Company';
+import Dashboard from './views/Dashboard';
 import Workspaces from './views/Workspaces';
 import Solutions from './views/Solutions';
-import Analytics from './views/Analytics';
 import Clients from './views/Clients';
 import Projects from './views/Projects';
 import Team from './views/Team';
@@ -17,18 +17,6 @@ import Tools from './views/Tools';
 import { DEFAULT_VIEW_ID } from './lib/navigation';
 import { getAvailablePages } from './utils/permissions';
 import type { ViewId } from './types/navigation';
-
-const VIEW_COMPONENTS: Record<ViewId, React.FC> = {
-  dashboard: Analytics,
-  analytics: Analytics,
-  company: Company,
-  clients: Clients,
-  projects: Projects,
-  team: Team,
-  workspaces: Workspaces,
-  tools: Tools,
-  solutions: Solutions,
-};
 
 const AppContent: React.FC = () => {
   const { user, account, isLoading } = useAuth();
@@ -65,7 +53,28 @@ const AppContent: React.FC = () => {
     );
   }
 
-  const ActiveView = VIEW_COMPONENTS[activeView] ?? Analytics;
+  const renderContent = () => {
+    switch (activeView) {
+      case 'dashboard':
+        return <Dashboard />;
+      case 'company':
+        return <Company />;
+      case 'clients':
+        return <Clients />;
+      case 'projects':
+        return <Projects />;
+      case 'team':
+        return <Team />;
+      case 'workspaces':
+        return <Workspaces />;
+      case 'tools':
+        return <Tools />;
+      case 'solutions':
+        return <Solutions />;
+      default:
+        return <Dashboard />;
+    }
+  };
 
   return (
     <div className="min-h-screen flex flex-col bg-[var(--bg-start)]">
@@ -73,9 +82,7 @@ const AppContent: React.FC = () => {
       <div className="flex-1 flex">
         <Sidebar activeView={activeView} availablePages={availablePages} onViewChange={setActiveView} />
         <div className="flex-1 flex flex-col">
-          <main className="flex-1 p-6 overflow-auto">
-            <ActiveView />
-          </main>
+          <main className="flex-1 p-6 overflow-auto">{renderContent()}</main>
         </div>
       </div>
       <Footer />

--- a/src/components/Dashboard/StatsCard.tsx
+++ b/src/components/Dashboard/StatsCard.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { DivideIcon as LucideIcon } from 'lucide-react';
+import type { LucideIcon } from 'lucide-react';
+
 import { Card } from '../Shared/Card';
 
 interface StatsCardProps {

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -14,7 +14,6 @@ export const AuthContext = createContext<AuthContextType | undefined>(undefined)
 
 const managerDefaultPages: ViewId[] = [
   'dashboard',
-  'analytics',
   'company',
   'clients',
   'projects',

--- a/src/hooks/useNotifications.ts
+++ b/src/hooks/useNotifications.ts
@@ -60,8 +60,8 @@ const generateMockNotifications = (accountType: string): Notification[] => {
       type: 'info',
       timestamp: new Date(Date.now() - 1000 * 60 * 60 * 24).toISOString(), // 1 day ago
       read: true,
-      actionUrl: 'analytics',
-      actionLabel: 'View Analytics'
+      actionUrl: 'dashboard',
+      actionLabel: 'View Dashboard'
     }
   ];
 

--- a/src/lib/navigation.ts
+++ b/src/lib/navigation.ts
@@ -1,6 +1,5 @@
 import {
   LayoutDashboard,
-  BarChart3,
   Building2,
   Handshake,
   FolderOpen,
@@ -14,7 +13,6 @@ import type { NavigationItem, ViewId } from '../types/navigation';
 
 export const NAVIGATION_ITEMS: NavigationItem[] = [
   { id: 'dashboard', label: 'Dashboard', icon: LayoutDashboard },
-  { id: 'analytics', label: 'Analytics', icon: BarChart3 },
   { id: 'company', label: 'Company', icon: Building2 },
   { id: 'clients', label: 'Clients', icon: Handshake },
   { id: 'projects', label: 'Projects', icon: FolderOpen },

--- a/src/types/navigation.ts
+++ b/src/types/navigation.ts
@@ -2,7 +2,6 @@ import type { LucideIcon } from 'lucide-react';
 
 export type ViewId =
   | 'dashboard'
-  | 'analytics'
   | 'company'
   | 'clients'
   | 'projects'

--- a/src/utils/permissions.ts
+++ b/src/utils/permissions.ts
@@ -8,7 +8,6 @@ const BUSINESS_RESTRICTED_PAGES: ViewId[] = ALL_PAGES.filter((page) => page !== 
 
 const CONTRACTOR_ALLOWED_PAGES: ViewId[] = [
   'dashboard',
-  'analytics',
   'projects',
   'team',
   'workspaces',

--- a/src/views/Dashboard.tsx
+++ b/src/views/Dashboard.tsx
@@ -1,0 +1,215 @@
+import React, { useMemo } from 'react';
+import { Handshake, FolderOpen, Users, Wrench } from 'lucide-react';
+
+import StatsCard from '../components/Dashboard/StatsCard';
+import { Card } from '../components/Shared/Card';
+import { useAuth } from '../hooks/useAuth';
+import { useClients } from '../hooks/useClients';
+import { useProjects } from '../hooks/useProjects';
+import { useTeam } from '../hooks/useTeam';
+import { useTools } from '../hooks/useTools';
+
+const ACTIVE_PROJECT_STATUSES = new Set(['planning', 'development', 'testing', 'maintenance']);
+
+const Dashboard: React.FC = () => {
+  const { user, account } = useAuth();
+  const { clients } = useClients();
+  const { projects } = useProjects();
+  const { teamMembers } = useTeam();
+  const { tools } = useTools();
+
+  const activeClients = useMemo(
+    () => clients.filter((client) => client.status === 'active'),
+    [clients]
+  );
+
+  const prospectClients = useMemo(
+    () => clients.filter((client) => client.status === 'prospect'),
+    [clients]
+  );
+
+  const activeProjects = useMemo(
+    () => projects.filter((project) => ACTIVE_PROJECT_STATUSES.has(project.status)),
+    [projects]
+  );
+
+  const deployedProjects = useMemo(
+    () => projects.filter((project) => project.status === 'deployed'),
+    [projects]
+  );
+
+  const activeTeamMembers = useMemo(
+    () => teamMembers.filter((member) => member.status === 'active'),
+    [teamMembers]
+  );
+
+  const activeTools = useMemo(
+    () => tools.filter((tool) => tool.status === 'active'),
+    [tools]
+  );
+
+  const toolsInTesting = useMemo(
+    () => tools.filter((tool) => tool.status === 'testing'),
+    [tools]
+  );
+
+  const automationCategories = useMemo(() => {
+    const categoryCounts = tools.reduce<Record<string, number>>((counts, tool) => {
+      counts[tool.category] = (counts[tool.category] ?? 0) + 1;
+      return counts;
+    }, {});
+
+    return Object.entries(categoryCounts)
+      .sort(([, aCount], [, bCount]) => bCount - aCount)
+      .slice(0, 3);
+  }, [tools]);
+
+  const highlightedClients = activeClients.slice(0, 3);
+  const highlightedProjects = activeProjects.slice(0, 3);
+
+  const summaryCards = [
+    {
+      title: 'Active Clients',
+      value: activeClients.length,
+      change: `${prospectClients.length} prospects`,
+      icon: Handshake,
+      changeTone: 'neutral' as const,
+    },
+    {
+      title: 'Projects in Motion',
+      value: activeProjects.length,
+      change: `${deployedProjects.length} deployed`,
+      icon: FolderOpen,
+      changeTone: 'positive' as const,
+    },
+    {
+      title: 'Team Members Engaged',
+      value: activeTeamMembers.length,
+      change: `${teamMembers.length} total collaborators`,
+      icon: Users,
+      changeTone: 'neutral' as const,
+    },
+    {
+      title: 'Active Automations',
+      value: activeTools.length,
+      change: `${toolsInTesting.length} in testing`,
+      icon: Wrench,
+      changeTone: toolsInTesting.length > 0 ? ('warning' as const) : ('positive' as const),
+    },
+  ];
+
+  return (
+    <div className="space-y-8">
+      <header className="flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
+        <div>
+          <p className="text-sm uppercase tracking-wide text-[var(--fg-muted)]">Dashboard Overview</p>
+          <h1 className="text-3xl font-bold text-[var(--fg)]">
+            {user ? `Welcome back, ${user.name.split(' ')[0]}!` : 'Welcome back!'}
+          </h1>
+          <p className="text-sm text-[var(--fg-muted)]">
+            {account
+              ? `Here’s how ${account.name} is performing across workstreams.`
+              : 'Here’s how your workspace is performing across workstreams.'}
+          </p>
+        </div>
+      </header>
+
+      <section className="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-4">
+        {summaryCards.map((card) => (
+          <StatsCard
+            key={card.title}
+            title={card.title}
+            value={card.value}
+            change={card.change}
+            icon={card.icon}
+            changeTone={card.changeTone}
+          />
+        ))}
+      </section>
+
+      <section className="grid grid-cols-1 gap-6 xl:grid-cols-2">
+        <Card className="p-6 space-y-4" glowOnHover>
+          <div className="flex items-center justify-between">
+            <h2 className="text-lg font-semibold text-[var(--fg)]">Client Highlights</h2>
+            <span className="text-sm text-[var(--fg-muted)]">{clients.length} total</span>
+          </div>
+          <ul className="space-y-3">
+            {highlightedClients.map((client) => (
+              <li
+                key={client.id}
+                className="flex items-start justify-between rounded-lg border border-[var(--border)] bg-[var(--surface)] px-4 py-3"
+              >
+                <div>
+                  <p className="font-medium text-[var(--fg)]">{client.companyName}</p>
+                  <p className="text-sm text-[var(--fg-muted)]">{client.industry}</p>
+                </div>
+                <span className="text-sm font-medium text-[var(--fg-muted)]">{client.projects.length} projects</span>
+              </li>
+            ))}
+            {highlightedClients.length === 0 && (
+              <li className="rounded-lg border border-dashed border-[var(--border)] bg-[var(--surface)] px-4 py-6 text-center text-sm text-[var(--fg-muted)]">
+                No active clients yet. Invite a client to get started.
+              </li>
+            )}
+          </ul>
+        </Card>
+
+        <Card className="p-6 space-y-4" glowOnHover>
+          <div className="flex items-center justify-between">
+            <h2 className="text-lg font-semibold text-[var(--fg)]">Project Momentum</h2>
+            <span className="text-sm text-[var(--fg-muted)]">{projects.length} total</span>
+          </div>
+          <ul className="space-y-3">
+            {highlightedProjects.map((project) => (
+              <li
+                key={project.id}
+                className="flex items-start justify-between rounded-lg border border-[var(--border)] bg-[var(--surface)] px-4 py-3"
+              >
+                <div>
+                  <p className="font-medium text-[var(--fg)]">{project.name}</p>
+                  <p className="text-sm text-[var(--fg-muted)] capitalize">{project.status}</p>
+                </div>
+                <span className="text-sm font-medium text-[var(--fg-muted)]">{project.systems.length} systems</span>
+              </li>
+            ))}
+            {highlightedProjects.length === 0 && (
+              <li className="rounded-lg border border-dashed border-[var(--border)] bg-[var(--surface)] px-4 py-6 text-center text-sm text-[var(--fg-muted)]">
+                No projects in motion. Create a project to track progress.
+              </li>
+            )}
+          </ul>
+        </Card>
+      </section>
+
+      <section>
+        <Card className="p-6 space-y-6" glowOnHover>
+          <div>
+            <h2 className="text-lg font-semibold text-[var(--fg)]">Automation Coverage</h2>
+            <p className="text-sm text-[var(--fg-muted)]">
+              Track where your automation efforts are concentrated across categories.
+            </p>
+          </div>
+          <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
+            {automationCategories.map(([category, count]) => (
+              <div
+                key={category}
+                className="rounded-lg border border-[var(--border)] bg-[var(--surface)] px-4 py-3"
+              >
+                <p className="text-sm font-medium text-[var(--fg)]">{category}</p>
+                <p className="mt-1 text-2xl font-semibold text-[var(--fg)]">{count}</p>
+                <p className="text-xs text-[var(--fg-muted)]">Active solutions</p>
+              </div>
+            ))}
+            {automationCategories.length === 0 && (
+              <div className="rounded-lg border border-dashed border-[var(--border)] bg-[var(--surface)] px-4 py-6 text-center text-sm text-[var(--fg-muted)]">
+                No automation tools yet. Add a tool to populate insights.
+              </div>
+            )}
+          </div>
+        </Card>
+      </section>
+    </div>
+  );
+};
+
+export default Dashboard;


### PR DESCRIPTION
## Summary
- add a dedicated dashboard overview screen that surfaces key metrics and highlights across clients, projects, and tooling
- switch the app shell back to a switch-based renderer that defaults to the new dashboard content and remove the legacy analytics view mapping
- synchronize navigation, permissions, and notifications to the new view set and fix the dashboard StatCard typing

## Testing
- npx tsc --noEmit

------
https://chatgpt.com/codex/tasks/task_e_68d074f4e82c832d895bfaa8d5a3d6f4