### PR TITLE
Align permissions metadata with new archive page

### DIFF
--- a/src/lib/navigation.ts
+++ b/src/lib/navigation.ts
@@ -7,6 +7,7 @@ import {
   PanelsTopLeft,
   Wrench,
   Share2,
+  Archive,
 } from 'lucide-react';
 
 import type { NavigationItem, ViewId } from '../types/navigation';
@@ -20,6 +21,7 @@ export const NAVIGATION_ITEMS: NavigationItem[] = [
   { id: 'workspaces', label: 'Workspaces', icon: PanelsTopLeft },
   { id: 'tools', label: 'Tools', icon: Wrench },
   { id: 'solutions', label: 'Solutions Hub', icon: Share2 },
+  { id: 'archive', label: 'Archive', icon: Archive },
 ];
 
 export const DEFAULT_VIEW_ID: ViewId = 'dashboard';

--- a/src/types/navigation.ts
+++ b/src/types/navigation.ts
@@ -8,7 +8,8 @@ export type ViewId =
   | 'team'
   | 'workspaces'
   | 'tools'
-  | 'solutions';
+  | 'solutions'
+  | 'archive';
 
 export interface NavigationItem {
   id: ViewId;

--- a/src/utils/permissions.ts
+++ b/src/utils/permissions.ts
@@ -2,9 +2,17 @@ import { NAVIGATION_ITEMS } from '../lib/navigation';
 import { User } from '../types';
 import type { ViewId } from '../types/navigation';
 
-const ALL_PAGES: ViewId[] = NAVIGATION_ITEMS.map((item) => item.id);
+export const allPages: ViewId[] = NAVIGATION_ITEMS.map((item) => item.id);
 
-const BUSINESS_RESTRICTED_PAGES: ViewId[] = ALL_PAGES.filter((page) => page !== 'clients');
+export const titles: Record<ViewId, string> = NAVIGATION_ITEMS.reduce(
+  (acc, item) => {
+    acc[item.id] = item.label;
+    return acc;
+  },
+  {} as Record<ViewId, string>,
+);
+
+const BUSINESS_RESTRICTED_PAGES: ViewId[] = allPages.filter((page) => page !== 'clients');
 
 const CONTRACTOR_ALLOWED_PAGES: ViewId[] = [
   'dashboard',
@@ -13,6 +21,7 @@ const CONTRACTOR_ALLOWED_PAGES: ViewId[] = [
   'workspaces',
   'tools',
   'solutions',
+  'archive',
 ];
 
 const CLIENT_ALLOWED_PAGES: ViewId[] = [
@@ -22,6 +31,7 @@ const CLIENT_ALLOWED_PAGES: ViewId[] = [
   'workspaces',
   'tools',
   'solutions',
+  'archive',
 ];
 
 const filterPages = (pages: ViewId[], allowed: ViewId[]): ViewId[] =>
@@ -31,8 +41,8 @@ export const getAvailablePages = (user: User): ViewId[] => {
   const { accountType, role, enabledPages } = user;
 
   const accountTypePages: Record<User['accountType'], ViewId[]> = {
-    agency: ALL_PAGES,
-    consultant: ALL_PAGES,
+    agency: allPages,
+    consultant: allPages,
     business: BUSINESS_RESTRICTED_PAGES,
   };
 
@@ -54,7 +64,4 @@ export const canAccessPage = (user: User, page: ViewId): boolean => {
   return availablePages.includes(page);
 };
 
-export const getPageTitle = (page: ViewId): string => {
-  const match = NAVIGATION_ITEMS.find((item) => item.id === page);
-  return match?.label ?? 'Dashboard';
-};
+export const getPageTitle = (page: ViewId): string => titles[page] ?? 'Dashboard';


### PR DESCRIPTION
## Summary
- derive `allPages` and `titles` from navigation so the archive view stays in sync
- include the archive view in contractor and client allow-lists
- add the archive navigation entry and update the shared view id type

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d07b5aca94832d8fa951244dda64c3