### PR TITLE
Unify time range helpers

### DIFF
--- a/src/utils/timeRanges.ts
+++ b/src/utils/timeRanges.ts
@@ -1,12 +1,22 @@
+import {
+  DATE_RANGE_OPTIONS,
+  getDateRange,
+  getDateRangeLabel,
+  isDateWithinRange,
+} from './dateRanges';
 import type { DateRangeKey as DateRangeKeyType } from './dateRanges';
+
+export type { DateRange, DateRangeKey, DateRangeOption } from './dateRanges';
+
+export const DEFAULT_TIME_RANGE: DateRangeKeyType = 'all';
+
+export const timeRangeOptions = DATE_RANGE_OPTIONS;
+
+export const isWithinTimeRange = isDateWithinRange;
 
 export {
   DATE_RANGE_OPTIONS,
   getDateRange,
   getDateRangeLabel,
   isDateWithinRange,
-} from './dateRanges';
-
-export type { DateRange, DateRangeKey, DateRangeOption } from './dateRanges';
-
-export const DEFAULT_TIME_RANGE: DateRangeKeyType = 'all';
+};

--- a/src/views/Clients.tsx
+++ b/src/views/Clients.tsx
@@ -20,12 +20,12 @@ import { useClients } from '../hooks/useClients';
 import { useAuth } from '../hooks/useAuth';
 import type { Client } from '../types';
 import {
-  DATE_RANGE_OPTIONS,
   DEFAULT_TIME_RANGE,
   DateRangeKey,
   getDateRange,
   getDateRangeLabel,
-  isDateWithinRange,
+  isWithinTimeRange,
+  timeRangeOptions,
 } from '../utils/timeRanges';
 
 type StatusFilterValue = 'all' | Client['status'];
@@ -179,7 +179,7 @@ const Clients: React.FC = () => {
         return false;
       }
 
-      if (!isDateWithinRange(client.updatedAt, range) && !isDateWithinRange(client.createdAt, range)) {
+      if (!isWithinTimeRange(client.updatedAt, range) && !isWithinTimeRange(client.createdAt, range)) {
         return false;
       }
 
@@ -364,7 +364,7 @@ const Clients: React.FC = () => {
                       <CalendarClock className="h-3.5 w-3.5" />
                       Time range
                     </span>
-                    {DATE_RANGE_OPTIONS.map((option) => {
+                    {timeRangeOptions.map((option) => {
                       const isActive = option.value === timeRange;
                       return (
                         <button

--- a/src/views/Projects.tsx
+++ b/src/views/Projects.tsx
@@ -16,12 +16,12 @@ import { Card } from '../components/Shared/Card';
 import { useProjects } from '../hooks/useProjects';
 import { Project } from '../types';
 import {
-  DATE_RANGE_OPTIONS,
   DEFAULT_TIME_RANGE,
   DateRangeKey,
   getDateRange,
   getDateRangeLabel,
-  isDateWithinRange,
+  isWithinTimeRange,
+  timeRangeOptions,
 } from '../utils/timeRanges';
 
 type StatusFilterValue = 'all' | Project['status'];
@@ -135,8 +135,8 @@ const Projects: React.FC = () => {
         return false;
       }
 
-      const createdMatches = isDateWithinRange(project.createdAt, range);
-      const updatedMatches = isDateWithinRange(project.updatedAt, range);
+      const createdMatches = isWithinTimeRange(project.createdAt, range);
+      const updatedMatches = isWithinTimeRange(project.updatedAt, range);
 
       return createdMatches || updatedMatches;
     });
@@ -237,7 +237,7 @@ const Projects: React.FC = () => {
                   <CalendarClock className="h-3.5 w-3.5" />
                   Time range
                 </span>
-                {DATE_RANGE_OPTIONS.map((option) => {
+                {timeRangeOptions.map((option) => {
                   const isActive = option.value === timeRange;
                   return (
                     <button


### PR DESCRIPTION
## Summary
- extend the shared time range utility to expose aliases for options and range checks used on both branches
- update Clients and Projects views to consume the new helper names so both implementations match

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68d0c9e76c28832d962b0e614364464b