### PR TITLE
Fix business team filtering to use workspace account

### DIFF
--- a/src/hooks/useTeam.ts
+++ b/src/hooks/useTeam.ts
@@ -347,16 +347,16 @@ export const useTeam = () => {
       
       if (user?.accountType === 'business') {
         // For business accounts, show team members who work on business projects
-        filteredMembers = mockTeamMembers.filter(member => 
-          member.companyName === user.account?.name ||
+        filteredMembers = mockTeamMembers.filter(member =>
+          member.companyName === account?.name ||
           member.projectIds.some(projectId => ['6', '7'].includes(projectId)) // Business project IDs
         );
       }
-      
+
       setTeamMembers(filteredMembers);
       setIsLoading(false);
     }, 500);
-  }, [user]);
+  }, [user, account]);
 
   const getTeamMembersByIds = (ids: string[]): TeamMember[] => {
     return teamMembers.filter(member => ids.includes(member.id));


### PR DESCRIPTION
## Summary
- use the workspace account name when filtering business team members so matching company records load for business logins
- include the account object in the team-loading effect dependencies after it is referenced

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d0d6e33998832da717cde9872e150d