### PR TITLE
Update navigation to current destinations

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,6 +10,7 @@ import Company from './views/Company';
 import Dashboard from './views/Dashboard';
 import Workspaces from './views/Workspaces';
 import Solutions from './views/Solutions';
+import Analytics from './views/Analytics';
 import Clients from './views/Clients';
 import Projects from './views/Projects';
 import Team from './views/Team';
@@ -17,6 +18,18 @@ import Tools from './views/Tools';
 import { DEFAULT_VIEW_ID } from './lib/navigation';
 import { getAvailablePages } from './utils/permissions';
 import type { ViewId } from './types/navigation';
+
+const VIEW_COMPONENTS: Record<ViewId, React.ComponentType> = {
+  dashboard: Dashboard,
+  company: Company,
+  clients: Clients,
+  projects: Projects,
+  team: Team,
+  workspaces: Workspaces,
+  tools: Tools,
+  solutions: Solutions,
+  analytics: Analytics,
+};
 
 const AppContent: React.FC = () => {
   const { user, account, isLoading } = useAuth();
@@ -53,28 +66,7 @@ const AppContent: React.FC = () => {
     );
   }
 
-  const renderContent = () => {
-    switch (activeView) {
-      case 'dashboard':
-        return <Dashboard />;
-      case 'company':
-        return <Company />;
-      case 'clients':
-        return <Clients />;
-      case 'projects':
-        return <Projects />;
-      case 'team':
-        return <Team />;
-      case 'workspaces':
-        return <Workspaces />;
-      case 'tools':
-        return <Tools />;
-      case 'solutions':
-        return <Solutions />;
-      default:
-        return <Dashboard />;
-    }
-  };
+  const ActiveViewComponent = VIEW_COMPONENTS[activeView] ?? VIEW_COMPONENTS[DEFAULT_VIEW_ID];
 
   return (
     <div className="min-h-screen flex flex-col bg-[var(--bg-start)]">
@@ -82,7 +74,9 @@ const AppContent: React.FC = () => {
       <div className="flex-1 flex">
         <Sidebar activeView={activeView} availablePages={availablePages} onViewChange={setActiveView} />
         <div className="flex-1 flex flex-col">
-          <main className="flex-1 p-6 overflow-auto">{renderContent()}</main>
+          <main className="flex-1 p-6 overflow-auto">
+            <ActiveViewComponent />
+          </main>
         </div>
       </div>
       <Footer />

--- a/src/components/Layout/Sidebar.tsx
+++ b/src/components/Layout/Sidebar.tsx
@@ -12,16 +12,12 @@ interface SidebarProps {
   onViewChange: (view: ViewId) => void;
 }
 
-const MENU_ITEM_IDS: ViewId[] = ['dashboard', 'company', 'clients', 'projects', 'team'];
-
-const allMenuItems = NAVIGATION_ITEMS.filter((item) => MENU_ITEM_IDS.includes(item.id));
-
 const Sidebar: React.FC<SidebarProps> = ({ activeView, availablePages, onViewChange }) => {
   const { user, account, logout } = useAuth();
 
   if (!user || !account) return null;
 
-  const menuItems = allMenuItems.filter((item) => availablePages.includes(item.id));
+  const menuItems = NAVIGATION_ITEMS.filter((item) => availablePages.includes(item.id));
 
   return (
     <div className="w-64 bg-[var(--bg-start)] border-r border-[var(--border)] flex flex-col">

--- a/src/lib/navigation.ts
+++ b/src/lib/navigation.ts
@@ -7,7 +7,7 @@ import {
   PanelsTopLeft,
   Wrench,
   Share2,
-  Archive,
+  BarChart3,
 } from 'lucide-react';
 
 import type { NavigationItem, ViewId } from '../types/navigation';
@@ -21,7 +21,7 @@ export const NAVIGATION_ITEMS: NavigationItem[] = [
   { id: 'workspaces', label: 'Workspaces', icon: PanelsTopLeft },
   { id: 'tools', label: 'Tools', icon: Wrench },
   { id: 'solutions', label: 'Solutions Hub', icon: Share2 },
-  { id: 'archive', label: 'Archive', icon: Archive },
+  { id: 'analytics', label: 'Analytics', icon: BarChart3 },
 ];
 
-export const DEFAULT_VIEW_ID: ViewId = 'dashboard';
+export const DEFAULT_VIEW_ID: ViewId = NAVIGATION_ITEMS[0]?.id ?? 'dashboard';

--- a/src/types/navigation.ts
+++ b/src/types/navigation.ts
@@ -9,7 +9,7 @@ export type ViewId =
   | 'workspaces'
   | 'tools'
   | 'solutions'
-  | 'archive';
+  | 'analytics';
 
 export interface NavigationItem {
   id: ViewId;

--- a/src/utils/permissions.ts
+++ b/src/utils/permissions.ts
@@ -21,7 +21,7 @@ const CONTRACTOR_ALLOWED_PAGES: ViewId[] = [
   'workspaces',
   'tools',
   'solutions',
-  'archive',
+  'analytics',
 ];
 
 const CLIENT_ALLOWED_PAGES: ViewId[] = [
@@ -31,7 +31,7 @@ const CLIENT_ALLOWED_PAGES: ViewId[] = [
   'workspaces',
   'tools',
   'solutions',
-  'archive',
+  'analytics',
 ];
 
 const filterPages = (pages: ViewId[], allowed: ViewId[]): ViewId[] =>


### PR DESCRIPTION
## Summary
- refresh NAVIGATION_ITEMS with the final menu (adding Analytics, removing Archive) and derive the default view from it
- adjust the sidebar to surface any allowed navigation entry and expose new views
- synchronize permissions and App view rendering with the updated navigation list

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d0d7cd80fc832d82d918913e2c5067