### PR TITLE
Enhance team view with time-aware metrics

### DIFF
--- a/src/components/Clients/TeamMemberModal.tsx
+++ b/src/components/Clients/TeamMemberModal.tsx
@@ -1,5 +1,20 @@
 import React from 'react';
-import { X, Mail, Phone, Linkedin, MapPin, BarChart3, Users, FolderOpen, Wrench, BookOpen, BookTemplate as FileTemplate, ShoppingBag, User } from 'lucide-react';
+import {
+  X,
+  Mail,
+  Phone,
+  Linkedin,
+  MapPin,
+  BarChart3,
+  Users,
+  FolderOpen,
+  Wrench,
+  BookOpen,
+  BookTemplate as FileTemplate,
+  ShoppingBag,
+  User,
+  CalendarClock,
+} from 'lucide-react';
 import { TeamMember } from '../../types';
 import { useClients } from '../../hooks/useClients';
 import { useProjects } from '../../hooks/useProjects';
@@ -65,6 +80,42 @@ const TeamMemberModal: React.FC<TeamMemberModalProps> = ({ member, onClose }) =>
     downloads: Math.floor(Math.random() * 100) + 10,
     rating: (Math.random() * 2 + 3).toFixed(1)
   }));
+
+  const formatDate = (value?: string) => {
+    if (!value) {
+      return '—';
+    }
+
+    const date = new Date(value);
+    if (Number.isNaN(date.getTime())) {
+      return '—';
+    }
+
+    return date.toLocaleDateString(undefined, {
+      month: 'short',
+      day: 'numeric',
+      year: 'numeric',
+    });
+  };
+
+  const formatDateTime = (value?: string) => {
+    if (!value) {
+      return '—';
+    }
+
+    const date = new Date(value);
+    if (Number.isNaN(date.getTime())) {
+      return '—';
+    }
+
+    return date.toLocaleString(undefined, {
+      month: 'short',
+      day: 'numeric',
+      year: 'numeric',
+      hour: '2-digit',
+      minute: '2-digit',
+    });
+  };
 
   return (
     <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4">
@@ -156,6 +207,37 @@ const TeamMemberModal: React.FC<TeamMemberModalProps> = ({ member, onClose }) =>
                         {skill}
                       </span>
                     ))}
+                  </div>
+                </div>
+
+                <div className="mt-6 grid grid-cols-1 gap-3 md:grid-cols-2 xl:grid-cols-4">
+                  <div className="flex items-center gap-3 rounded-lg border border-white/20 bg-white/30 p-4 backdrop-blur-sm dark:border-white/10 dark:bg-white/10">
+                    <CalendarClock className="h-5 w-5 text-[var(--accent-purple)]" />
+                    <div>
+                      <p className="text-xs uppercase tracking-wide text-gray-600 dark:text-gray-300">Joined</p>
+                      <p className="text-sm font-semibold text-gray-900 dark:text-white">{formatDate(member.createdAt)}</p>
+                    </div>
+                  </div>
+                  <div className="flex items-center gap-3 rounded-lg border border-white/20 bg-white/30 p-4 backdrop-blur-sm dark:border-white/10 dark:bg-white/10">
+                    <CalendarClock className="h-5 w-5 text-[var(--accent-purple)]" />
+                    <div>
+                      <p className="text-xs uppercase tracking-wide text-gray-600 dark:text-gray-300">Last Active</p>
+                      <p className="text-sm font-semibold text-gray-900 dark:text-white">{formatDateTime(member.lastActiveAt)}</p>
+                    </div>
+                  </div>
+                  <div className="flex items-center gap-3 rounded-lg border border-white/20 bg-white/30 p-4 backdrop-blur-sm dark:border-white/10 dark:bg-white/10">
+                    <CalendarClock className="h-5 w-5 text-[var(--accent-purple)]" />
+                    <div>
+                      <p className="text-xs uppercase tracking-wide text-gray-600 dark:text-gray-300">Last Assignment</p>
+                      <p className="text-sm font-semibold text-gray-900 dark:text-white">{formatDateTime(member.lastAssignedAt)}</p>
+                    </div>
+                  </div>
+                  <div className="flex items-center gap-3 rounded-lg border border-white/20 bg-white/30 p-4 backdrop-blur-sm dark:border-white/10 dark:bg-white/10">
+                    <CalendarClock className="h-5 w-5 text-[var(--accent-purple)]" />
+                    <div>
+                      <p className="text-xs uppercase tracking-wide text-gray-600 dark:text-gray-300">Profile Updated</p>
+                      <p className="text-sm font-semibold text-gray-900 dark:text-white">{formatDateTime(member.updatedAt)}</p>
+                    </div>
                   </div>
                 </div>
               </div>

--- a/src/hooks/useTeam.ts
+++ b/src/hooks/useTeam.ts
@@ -11,7 +11,7 @@ const mockTeamMembers: TeamMember[] = [
     role: 'employee',
     skills: ['Machine Learning', 'Python', 'Data Analysis', 'API Development'],
     projectIds: ['proj-1', 'proj-5', 'proj-10'],
-    status: 'active',
+    status: 'inactive',
     phone: '+1 (555) 123-4567',
     linkedinUrl: 'https://linkedin.com/in/lisapark',
     city: 'San Francisco',
@@ -32,7 +32,11 @@ const mockTeamMembers: TeamMember[] = [
     toolIds: ['tool-1', 'tool-2', 'tool-3'],
     libraryItemIds: ['lib-1', 'lib-2', 'lib-3'],
     templateIds: ['temp-1', 'temp-2'],
-    marketplaceItemIds: ['mp-1', 'mp-2']
+    marketplaceItemIds: ['mp-1', 'mp-2'],
+    createdAt: '2023-04-12T14:32:00.000Z',
+    updatedAt: '2024-07-08T16:45:00.000Z',
+    lastActiveAt: '2024-07-11T09:15:00.000Z',
+    lastAssignedAt: '2024-07-05T13:00:00.000Z'
   },
   {
     id: 'tm-4',
@@ -62,7 +66,11 @@ const mockTeamMembers: TeamMember[] = [
     toolIds: ['tool-2', 'tool-4', 'tool-5'],
     libraryItemIds: ['lib-2', 'lib-4', 'lib-5'],
     templateIds: ['temp-2', 'temp-3', 'temp-4'],
-    marketplaceItemIds: ['mp-2', 'mp-3', 'mp-4']
+    marketplaceItemIds: ['mp-2', 'mp-3', 'mp-4'],
+    createdAt: '2022-11-03T18:20:00.000Z',
+    updatedAt: '2024-06-18T20:10:00.000Z',
+    lastActiveAt: '2024-06-20T17:05:00.000Z',
+    lastAssignedAt: '2024-06-19T15:30:00.000Z'
   },
   {
     id: 'tm-5',
@@ -92,7 +100,11 @@ const mockTeamMembers: TeamMember[] = [
     toolIds: ['tool-business-1', 'tool-business-2'],
     libraryItemIds: ['lib-business-1', 'lib-business-2'],
     templateIds: ['temp-business-1'],
-    marketplaceItemIds: ['mp-business-1']
+    marketplaceItemIds: ['mp-business-1'],
+    createdAt: '2024-06-15T12:00:00.000Z',
+    updatedAt: '2024-07-10T11:20:00.000Z',
+    lastActiveAt: '2024-07-09T10:45:00.000Z',
+    lastAssignedAt: '2024-06-30T08:30:00.000Z'
   },
   {
     id: 'tm-6',
@@ -122,7 +134,11 @@ const mockTeamMembers: TeamMember[] = [
     toolIds: ['tool-4', 'tool-5', 'tool-6'],
     libraryItemIds: ['lib-4', 'lib-5', 'lib-6'],
     templateIds: ['temp-4', 'temp-5'],
-    marketplaceItemIds: ['mp-3', 'mp-5', 'mp-6']
+    marketplaceItemIds: ['mp-3', 'mp-5', 'mp-6'],
+    createdAt: '2023-08-21T09:30:00.000Z',
+    updatedAt: '2024-07-07T18:55:00.000Z',
+    lastActiveAt: '2024-07-08T14:40:00.000Z',
+    lastAssignedAt: '2024-07-06T19:15:00.000Z'
   },
   {
     id: 'tm-7',
@@ -152,7 +168,11 @@ const mockTeamMembers: TeamMember[] = [
     toolIds: ['tool-1', 'tool-7', 'tool-8'],
     libraryItemIds: ['lib-1', 'lib-7'],
     templateIds: ['temp-1', 'temp-6'],
-    marketplaceItemIds: ['mp-1', 'mp-7']
+    marketplaceItemIds: ['mp-1', 'mp-7'],
+    createdAt: '2021-02-19T15:10:00.000Z',
+    updatedAt: '2024-06-29T16:05:00.000Z',
+    lastActiveAt: '2024-06-27T13:25:00.000Z',
+    lastAssignedAt: '2024-06-15T09:00:00.000Z'
   },
   {
     id: 'tm-8',
@@ -182,7 +202,11 @@ const mockTeamMembers: TeamMember[] = [
     toolIds: ['tool-2', 'tool-3'],
     libraryItemIds: ['lib-2', 'lib-3'],
     templateIds: ['temp-2', 'temp-3'],
-    marketplaceItemIds: ['mp-2']
+    marketplaceItemIds: ['mp-2'],
+    createdAt: '2022-06-07T13:45:00.000Z',
+    updatedAt: '2024-07-11T07:50:00.000Z',
+    lastActiveAt: '2024-07-10T16:20:00.000Z',
+    lastAssignedAt: '2024-07-09T18:05:00.000Z'
   },
   {
     id: 'tm-9',
@@ -212,7 +236,11 @@ const mockTeamMembers: TeamMember[] = [
     toolIds: ['tool-1', 'tool-6', 'tool-9'],
     libraryItemIds: ['lib-1', 'lib-6', 'lib-8'],
     templateIds: ['temp-1', 'temp-7', 'temp-8'],
-    marketplaceItemIds: ['mp-1', 'mp-8', 'mp-9']
+    marketplaceItemIds: ['mp-1', 'mp-8', 'mp-9'],
+    createdAt: '2021-12-01T10:00:00.000Z',
+    updatedAt: '2024-05-30T21:10:00.000Z',
+    lastActiveAt: '2024-05-24T12:35:00.000Z',
+    lastAssignedAt: '2024-05-20T14:45:00.000Z'
   },
   {
     id: 'tm-10',
@@ -242,7 +270,11 @@ const mockTeamMembers: TeamMember[] = [
     toolIds: ['tool-10', 'tool-11'],
     libraryItemIds: ['lib-9', 'lib-10'],
     templateIds: ['temp-9'],
-    marketplaceItemIds: ['mp-10', 'mp-11']
+    marketplaceItemIds: ['mp-10', 'mp-11'],
+    createdAt: '2023-09-03T08:20:00.000Z',
+    updatedAt: '2024-07-06T15:55:00.000Z',
+    lastActiveAt: '2024-07-05T17:40:00.000Z',
+    lastAssignedAt: '2024-07-05T11:30:00.000Z'
   },
   {
     id: 'tm-11',
@@ -272,7 +304,11 @@ const mockTeamMembers: TeamMember[] = [
     toolIds: ['tool-12', 'tool-13'],
     libraryItemIds: ['lib-11', 'lib-12'],
     templateIds: ['temp-10', 'temp-11'],
-    marketplaceItemIds: ['mp-12', 'mp-13']
+    marketplaceItemIds: ['mp-12', 'mp-13'],
+    createdAt: '2022-01-15T11:15:00.000Z',
+    updatedAt: '2024-06-02T10:30:00.000Z',
+    lastActiveAt: '2024-05-28T09:05:00.000Z',
+    lastAssignedAt: '2024-05-12T13:20:00.000Z'
   },
   {
     id: 'tm-12',
@@ -302,7 +338,11 @@ const mockTeamMembers: TeamMember[] = [
     toolIds: ['tool-business-3'],
     libraryItemIds: ['lib-business-3'],
     templateIds: ['temp-business-2'],
-    marketplaceItemIds: ['mp-business-2']
+    marketplaceItemIds: ['mp-business-2'],
+    createdAt: '2024-07-02T14:05:00.000Z',
+    updatedAt: '2024-07-09T16:45:00.000Z',
+    lastActiveAt: '2024-07-08T12:25:00.000Z',
+    lastAssignedAt: '2024-07-02T15:10:00.000Z'
   }
 ];
 
@@ -321,6 +361,10 @@ type TeamMemberInput = Pick<TeamMember, 'name' | 'email' | 'role' | 'status'> & 
   templateIds?: string[];
   marketplaceItemIds?: string[];
   analytics?: Partial<TeamMemberAnalytics>;
+  createdAt?: string;
+  updatedAt?: string;
+  lastActiveAt?: string;
+  lastAssignedAt?: string;
 };
 
 const defaultTeamAnalytics: TeamMemberAnalytics = {
@@ -367,6 +411,13 @@ export const useTeam = () => {
   };
 
   const createTeamMember = (memberData: TeamMemberInput) => {
+    const now = new Date().toISOString();
+    const createdAt = memberData.createdAt ?? now;
+    const lastActiveAt = memberData.lastActiveAt ?? now;
+    const updatedAt = memberData.updatedAt ?? now;
+    const lastAssignedAt =
+      memberData.lastAssignedAt ?? (memberData.projectIds && memberData.projectIds.length > 0 ? now : undefined);
+
     const newMember: TeamMember = {
       id: Date.now().toString(),
       name: memberData.name,
@@ -390,6 +441,10 @@ export const useTeam = () => {
       libraryItemIds: memberData.libraryItemIds || [],
       templateIds: memberData.templateIds || [],
       marketplaceItemIds: memberData.marketplaceItemIds || [],
+      createdAt,
+      updatedAt,
+      lastActiveAt,
+      lastAssignedAt,
     };
     setTeamMembers(prev => [...prev, newMember]);
     return newMember;
@@ -400,6 +455,10 @@ export const useTeam = () => {
       if (member.id !== id) {
         return member;
       }
+
+      const nextUpdatedAt = updates.updatedAt ?? new Date().toISOString();
+      const nextLastActiveAt = updates.lastActiveAt ?? member.lastActiveAt;
+      const nextLastAssignedAt = updates.lastAssignedAt ?? member.lastAssignedAt;
 
       return {
         ...member,
@@ -418,6 +477,9 @@ export const useTeam = () => {
         analytics: updates.analytics
           ? { ...member.analytics, ...updates.analytics }
           : member.analytics,
+        updatedAt: nextUpdatedAt,
+        lastActiveAt: nextLastActiveAt,
+        lastAssignedAt: nextLastAssignedAt,
       };
     }));
   };

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -87,6 +87,10 @@ export interface TeamMember {
   libraryItemIds: string[];
   templateIds: string[];
   marketplaceItemIds: string[];
+  createdAt: string;
+  updatedAt: string;
+  lastActiveAt: string;
+  lastAssignedAt?: string;
 }
 
 export interface TeamMemberAnalytics {

--- a/src/views/Team.tsx
+++ b/src/views/Team.tsx
@@ -1,188 +1,555 @@
-import React, { useState } from 'react';
-import { Plus, Users, Mail, Phone, MapPin, BarChart3, User } from 'lucide-react';
-import { useTeam } from '../hooks/useTeam';
+import React, { useMemo, useState } from 'react';
+import type { LucideIcon } from 'lucide-react';
+import {
+  Activity,
+  CalendarClock,
+  Filter,
+  Mail,
+  MapPin,
+  Phone,
+  Plus,
+  Search,
+  Sparkles,
+  Users,
+  UserCheck,
+} from 'lucide-react';
 import TeamMemberModal from '../components/Clients/TeamMemberModal';
 import { Card } from '../components/Shared/Card';
+import { useTeam } from '../hooks/useTeam';
+import type { TeamMember } from '../types';
+import {
+  DEFAULT_TIME_RANGE,
+  DateRangeKey,
+  getDateRange,
+  getDateRangeLabel,
+  isWithinTimeRange,
+  timeRangeOptions,
+} from '../utils/timeRanges';
+
+const roleOrder: TeamMember['role'][] = ['manager', 'employee', 'contractor'];
+
+type RoleFilterValue = 'all' | TeamMember['role'];
+type MetricKey = 'total' | 'active' | 'new' | 'engaged';
+type RangeValue = ReturnType<typeof getDateRange>;
+
+interface MetricDefinition {
+  key: MetricKey;
+  label: string;
+  description: string;
+  icon: LucideIcon;
+  accentClass: string;
+  predicate: (member: TeamMember, range: RangeValue) => boolean;
+}
+
+const getEffectiveRecentRange = (range: RangeValue) => range ?? getDateRange('last-30-days');
+
+const joinedWithinRange = (member: TeamMember, range: RangeValue) => {
+  const effectiveRange = getEffectiveRecentRange(range);
+  return isWithinTimeRange(member.createdAt, effectiveRange);
+};
+
+const hasRecentActivity = (member: TeamMember, range: RangeValue) => {
+  const effectiveRange = getEffectiveRecentRange(range);
+  return (
+    isWithinTimeRange(member.lastActiveAt, effectiveRange) ||
+    isWithinTimeRange(member.lastAssignedAt, effectiveRange)
+  );
+};
+
+const METRIC_DEFINITIONS: MetricDefinition[] = [
+  {
+    key: 'total',
+    label: 'Team Members',
+    description: 'In this view',
+    icon: Users,
+    accentClass: 'text-[var(--accent-orange)]',
+    predicate: () => true,
+  },
+  {
+    key: 'active',
+    label: 'Active',
+    description: 'Status: active',
+    icon: UserCheck,
+    accentClass: 'text-emerald-500',
+    predicate: (member) => member.status === 'active',
+  },
+  {
+    key: 'new',
+    label: 'New',
+    description: 'Joined this range',
+    icon: Sparkles,
+    accentClass: 'text-amber-500',
+    predicate: (member, range) => joinedWithinRange(member, range),
+  },
+  {
+    key: 'engaged',
+    label: 'Engaged',
+    description: 'Collaboration this range',
+    icon: Activity,
+    accentClass: 'text-sky-500',
+    predicate: (member, range) => hasRecentActivity(member, range),
+  },
+];
+
+const METRIC_BY_KEY = METRIC_DEFINITIONS.reduce<Record<MetricKey, MetricDefinition>>(
+  (acc, definition) => {
+    acc[definition.key] = definition;
+    return acc;
+  },
+  {} as Record<MetricKey, MetricDefinition>,
+);
+
+const normalizeSearchValue = (value: string | null | undefined) =>
+  (value || '')
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .toLowerCase();
+
+const formatRoleLabel = (role: TeamMember['role']) =>
+  role.charAt(0).toUpperCase() + role.slice(1);
+
+const formatDate = (value: string) => {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return '—';
+  }
+
+  return date.toLocaleDateString(undefined, {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+  });
+};
 
 const Team: React.FC = () => {
   const { teamMembers, isLoading } = useTeam();
-  const [selectedTeamMember, setSelectedTeamMember] = useState(null);
+  const [selectedTeamMember, setSelectedTeamMember] = useState<TeamMember | null>(null);
+  const [searchTerm, setSearchTerm] = useState('');
+  const [roleFilter, setRoleFilter] = useState<RoleFilterValue>('all');
+  const [activeMetric, setActiveMetric] = useState<MetricKey>('total');
+  const [timeRange, setTimeRange] = useState<DateRangeKey>(DEFAULT_TIME_RANGE);
+
+  const normalizedSearch = useMemo(
+    () => normalizeSearchValue(searchTerm.trim()),
+    [searchTerm],
+  );
+  const activeRange = useMemo(() => getDateRange(timeRange), [timeRange]);
+
+  const availableRoles = useMemo(() => {
+    const roles = new Set<TeamMember['role']>();
+    teamMembers.forEach((member) => roles.add(member.role));
+
+    return roleOrder.filter((role) => roles.has(role));
+  }, [teamMembers]);
+
+  const baseFilteredMembers = useMemo(
+    () =>
+      teamMembers.filter((member) => {
+        if (normalizedSearch) {
+          const fieldMatches = [
+            member.name,
+            member.email,
+            member.role,
+            member.companyName,
+            member.city,
+            member.state,
+          ]
+            .filter(Boolean)
+            .map((value) => normalizeSearchValue(value))
+            .some((value) => value.includes(normalizedSearch));
+
+          const skillMatches = member.skills
+            .map((skill) => normalizeSearchValue(skill))
+            .some((value) => value.includes(normalizedSearch));
+
+          if (!fieldMatches && !skillMatches) {
+            return false;
+          }
+        }
+
+        if (roleFilter !== 'all' && member.role !== roleFilter) {
+          return false;
+        }
+
+        if (activeRange) {
+          const relevantDates = [
+            member.createdAt,
+            member.updatedAt,
+            member.lastActiveAt,
+            member.lastAssignedAt,
+          ].filter((value): value is string => Boolean(value));
+
+          if (!relevantDates.some((date) => isWithinTimeRange(date, activeRange))) {
+            return false;
+          }
+        }
+
+        return true;
+      }),
+    [teamMembers, normalizedSearch, roleFilter, activeRange],
+  );
+
+  const filteredMembers = useMemo(() => {
+    const definition = METRIC_BY_KEY[activeMetric];
+
+    if (!definition) {
+      return baseFilteredMembers;
+    }
+
+    return baseFilteredMembers.filter((member) => definition.predicate(member, activeRange));
+  }, [baseFilteredMembers, activeMetric, activeRange]);
+
+  const metricCounts = useMemo(() => {
+    const counts: Record<MetricKey, number> = {
+      total: 0,
+      active: 0,
+      new: 0,
+      engaged: 0,
+    };
+
+    baseFilteredMembers.forEach((member) => {
+      METRIC_DEFINITIONS.forEach((definition) => {
+        if (definition.predicate(member, activeRange)) {
+          counts[definition.key] += 1;
+        }
+      });
+    });
+
+    return counts;
+  }, [baseFilteredMembers, activeRange]);
+
+  const activeFilterChips = useMemo(() => {
+    const chips: string[] = [];
+    const trimmedSearch = searchTerm.trim();
+
+    if (trimmedSearch) {
+      chips.push(`Search: "${trimmedSearch}"`);
+    }
+
+    if (roleFilter !== 'all') {
+      chips.push(`Role: ${formatRoleLabel(roleFilter)}`);
+    }
+
+    if (activeMetric !== 'total') {
+      chips.push(`Metric: ${METRIC_BY_KEY[activeMetric].label}`);
+    }
+
+    if (timeRange !== DEFAULT_TIME_RANGE) {
+      chips.push(`Range: ${getDateRangeLabel(timeRange)}`);
+    }
+
+    return chips;
+  }, [searchTerm, roleFilter, activeMetric, timeRange]);
+
+  const handleMetricSelect = (key: MetricKey) => {
+    setActiveMetric((previous) => (previous === key && key !== 'total' ? 'total' : key));
+  };
 
   if (isLoading) {
     return (
-      <div className="flex items-center justify-center h-64">
-        <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-sunset-purple"></div>
+      <div className="flex h-64 items-center justify-center">
+        <div className="h-12 w-12 animate-spin rounded-full border-b-2 border-[var(--accent-purple)]" />
       </div>
     );
   }
 
-  // Calculate team statistics
-  const activeMembers = teamMembers.filter(member => member.status === 'active').length;
-  const avgProductivity = teamMembers.length > 0
-    ? Math.round(teamMembers.reduce((sum, member) => sum + member.analytics.monthlyProductivity, 0) / teamMembers.length)
-    : 0;
-  const totalHours = teamMembers.reduce((sum, member) => sum + member.analytics.hoursWorked, 0);
-
   return (
     <div className="space-y-6">
-      <div className="flex justify-between items-center">
-        <div>
-          <h1 className="text-2xl font-bold text-[var(--fg)]">Team</h1>
-          <p className="text-[var(--fg-muted)]">Manage your team members and track their performance</p>
-        </div>
-        <button className="bg-sunset-orange text-white font-semibold py-2 px-4 rounded-lg hover:opacity-90 transition-opacity flex items-center space-x-2">
-          <Plus className="w-5 h-5" />
-          <span>Add Team Member</span>
-        </button>
-      </div>
-
-      {/* Team Stats */}
-      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
-        <Card className="p-6">
-          <div className="flex items-center justify-between">
+      <div className="space-y-4">
+        <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+          <div className="space-y-3">
             <div>
-              <p className="text-sm font-medium text-[var(--fg-muted)]">Total Members</p>
-              <p className="text-3xl font-bold text-[var(--fg)] mt-2">{teamMembers.length}</p>
-            </div>
-            <div className="p-3 bg-[var(--surface)] rounded-lg">
-              <Users className="w-6 h-6 text-[var(--fg-muted)]" />
-            </div>
-          </div>
-        </Card>
-
-        <Card className="p-6">
-          <div className="flex items-center justify-between">
-            <div>
-              <p className="text-sm font-medium text-[var(--fg-muted)]">Active Members</p>
-              <p className="text-3xl font-bold text-[var(--fg)] mt-2">{activeMembers}</p>
-              <p className="text-sm text-green-600 dark:text-green-400 mt-1">
-                {Math.round((activeMembers / teamMembers.length) * 100)}% active
+              <h1 className="text-2xl font-semibold text-[var(--fg)]">Team</h1>
+              <p className="text-sm text-[var(--fg-muted)]">
+                Search, filter, and spotlight the teammates keeping delivery on track.
               </p>
             </div>
-            <div className="p-3 bg-[var(--surface)] rounded-lg">
-              <User className="w-6 h-6 text-[var(--fg-muted)]" />
-            </div>
-          </div>
-        </Card>
 
-        <Card className="p-6">
-          <div className="flex items-center justify-between">
-            <div>
-              <p className="text-sm font-medium text-[var(--fg-muted)]">Avg Productivity</p>
-              <p className="text-3xl font-bold text-[var(--fg)] mt-2">{avgProductivity}%</p>
-              <p className="text-sm text-blue-600 dark:text-blue-400 mt-1">This month</p>
-            </div>
-            <div className="p-3 bg-[var(--surface)] rounded-lg">
-              <BarChart3 className="w-6 h-6 text-[var(--fg-muted)]" />
-            </div>
-          </div>
-        </Card>
-
-        <Card className="p-6">
-          <div className="flex items-center justify-between">
-            <div>
-              <p className="text-sm font-medium text-[var(--fg-muted)]">Total Hours</p>
-              <p className="text-3xl font-bold text-[var(--fg)] mt-2">{totalHours.toLocaleString()}</p>
-              <p className="text-sm text-purple-600 dark:text-purple-400 mt-1">All time</p>
-            </div>
-            <div className="p-3 bg-[var(--surface)] rounded-lg">
-              <BarChart3 className="w-6 h-6 text-[var(--fg-muted)]" />
-            </div>
-          </div>
-        </Card>
-      </div>
-
-      {/* Team Members Grid */}
-      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-        {teamMembers.map((member) => (
-          <Card
-            key={member.id}
-            glowOnHover={true}
-            onClick={() => setSelectedTeamMember(member)}
-            className="p-6 group"
-          >
-            <div className="flex items-start justify-between mb-4">
-              <div className="flex items-center space-x-3">
-                <div className="w-12 h-12 bg-gradient-primary rounded-full flex items-center justify-center">
-                  <span className="text-lg font-bold text-white">
-                    {member.name.split(' ').map(n => n[0]).join('')}
-                  </span>
-                </div>
-                <div>
-                  <h3 className="text-lg font-semibold text-gray-900 dark:text-white group-hover:text-gradient-orange transition-colors">
-                    {member.name}
-                  </h3>
-                  <p className="text-sm text-[var(--fg-muted)] capitalize">{member.role}</p>
-                </div>
-              </div>
-              <div className={`w-3 h-3 rounded-full ${
-                member.status === 'active' ? 'bg-green-400' : 'bg-gray-400'
-              }`} />
-            </div>
-
-            <div className="space-y-3">
-              <div className="flex items-center space-x-2 text-sm text-[var(--fg-muted)]">
-                <Mail className="w-4 h-4" />
-                <span className="text-[var(--fg)] truncate">{member.email}</span>
+            <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
+              <div className="relative flex-1 max-w-xl">
+                <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-[var(--fg-muted)]" />
+                <input
+                  className="w-full rounded-lg border border-[var(--border)] bg-[var(--surface)] py-2 pl-9 pr-3 text-sm text-[var(--fg)] focus:outline-none focus:ring-2 focus:ring-[var(--accent-purple)]"
+                  placeholder="Search by name, role, skill, or location"
+                  value={searchTerm}
+                  onChange={(event) => setSearchTerm(event.target.value)}
+                />
               </div>
 
-              {member.phone && (
-                <div className="flex items-center space-x-2 text-sm text-[var(--fg-muted)]">
-                  <Phone className="w-4 h-4" />
-                  <span className="text-[var(--fg)]">{member.phone}</span>
-                </div>
-              )}
-
-              {member.city && member.state && (
-                <div className="flex items-center space-x-2 text-sm text-[var(--fg-muted)]">
-                  <MapPin className="w-4 h-4" />
-                  <span className="text-[var(--fg)]">{member.city}, {member.state}</span>
-                </div>
-              )}
-            </div>
-
-            <div className="mt-4 pt-4 border-t border-[var(--border)]">
-              <div className="grid grid-cols-2 gap-4 text-sm">
-                <div className="text-center">
-                  <div className="text-lg font-bold text-[var(--fg)]">{member.projectIds.length}</div>
-                  <div className="text-xs text-[var(--fg-muted)]">Projects</div>
-                </div>
-                <div className="text-center">
-                  <div className="text-lg font-bold text-[var(--fg)]">{member.analytics.monthlyProductivity}%</div>
-                  <div className="text-xs text-[var(--fg-muted)]">Productivity</div>
-                </div>
+              <div className="flex flex-wrap items-center gap-2">
+                <span className="flex items-center gap-1.5 text-xs font-semibold uppercase tracking-wide text-[var(--fg-muted)]">
+                  <CalendarClock className="h-3.5 w-3.5" />
+                  Time range
+                </span>
+                {timeRangeOptions.map((option) => {
+                  const isActive = option.value === timeRange;
+                  return (
+                    <button
+                      key={option.value}
+                      type="button"
+                      onClick={() => setTimeRange(option.value)}
+                      aria-pressed={isActive}
+                      className={`rounded-full border px-3 py-1.5 text-xs font-medium transition focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent-purple)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--card)] ${
+                        isActive
+                          ? 'border-transparent bg-gradient-to-r from-[var(--accent-orange)] via-[var(--accent-pink)] to-[var(--accent-purple)] text-white shadow-sm'
+                          : 'border-[var(--border)] bg-[var(--surface)] text-[var(--fg-muted)] hover:text-[var(--fg)]'
+                      }`}
+                    >
+                      {option.label}
+                    </button>
+                  );
+                })}
               </div>
             </div>
+          </div>
 
-            <div className="mt-4">
-              <div className="flex flex-wrap gap-1">
-                {member.skills.slice(0, 3).map((skill, index) => (
-                  <span key={index} className="px-2 py-1 bg-[var(--surface)] text-[var(--fg-muted)] text-xs rounded-md">
-                    {skill}
-                  </span>
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:self-end lg:self-start">
+            <div className="relative">
+              <Filter className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-[var(--fg-muted)]" />
+              <select
+                className="appearance-none rounded-lg border border-[var(--border)] bg-[var(--surface)] py-2 pl-9 pr-8 text-sm text-[var(--fg)] focus:outline-none focus:ring-2 focus:ring-[var(--accent-purple)]"
+                value={roleFilter}
+                onChange={(event) => setRoleFilter(event.target.value as RoleFilterValue)}
+              >
+                <option value="all">All roles</option>
+                {availableRoles.map((role) => (
+                  <option key={role} value={role}>
+                    {formatRoleLabel(role)}
+                  </option>
                 ))}
-                {member.skills.length > 3 && (
-                  <span className="px-2 py-1 bg-[var(--surface)] text-[var(--fg-muted)] text-xs rounded-md">
-                    +{member.skills.length - 3} more
-                  </span>
-                )}
-              </div>
+              </select>
             </div>
-          </Card>
-        ))}
+
+            <button
+              type="button"
+              className="flex items-center gap-2 rounded-lg bg-gradient-to-r from-[var(--accent-orange)] via-[var(--accent-pink)] to-[var(--accent-purple)] px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:opacity-90"
+            >
+              <Plus className="h-4 w-4" />
+              Add Team Member
+            </button>
+          </div>
+        </div>
       </div>
 
-      {teamMembers.length === 0 && (
-        <div className="text-center py-12">
-          <div className="text-[var(--fg-muted)] mb-4">No team members found</div>
-          <button className="bg-sunset-orange text-white font-semibold py-2 px-4 rounded-lg hover:opacity-90 transition-opacity flex items-center space-x-2 mx-auto">
-            <Plus className="w-5 h-5" />
-            <span>Add Your First Team Member</span>
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-4">
+        {METRIC_DEFINITIONS.map((definition) => {
+          const count = metricCounts[definition.key] ?? 0;
+          const isActive = activeMetric === definition.key;
+          const Icon = definition.icon;
+
+          return (
+            <button
+              key={definition.key}
+              type="button"
+              onClick={() => handleMetricSelect(definition.key)}
+              aria-pressed={isActive}
+              className="w-full rounded-2xl text-left focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent-purple)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--card)]"
+            >
+              <Card glowOnHover activeGlow={isActive} className="h-full p-5">
+                <div className="flex h-full flex-col justify-between gap-4">
+                  <div className="flex items-start justify-between gap-4">
+                    <div>
+                      <p className="text-xs font-semibold uppercase tracking-wide text-[var(--fg-muted)]">
+                        {definition.label}
+                      </p>
+                      <p className="mt-2 text-3xl font-semibold text-[var(--fg)]">{count}</p>
+                      <p className="mt-1 text-xs text-[var(--fg-muted)]">{definition.description}</p>
+                    </div>
+                    <div
+                      className={`rounded-lg p-2 ${
+                        isActive ? 'bg-[var(--surface)]/80' : 'bg-[var(--surface)]/60'
+                      }`}
+                    >
+                      <Icon
+                        className={`h-5 w-5 ${
+                          isActive ? definition.accentClass : 'text-[var(--fg-muted)]'
+                        }`}
+                      />
+                    </div>
+                  </div>
+                  <div className="text-xs text-[var(--fg-muted)]">
+                    {isActive
+                      ? 'Click again to view all team members'
+                      : 'Click to focus the roster'}
+                  </div>
+                </div>
+              </Card>
+            </button>
+          );
+        })}
+      </div>
+
+      <div className="flex flex-col gap-2 text-sm text-[var(--fg-muted)] sm:flex-row sm:items-center sm:justify-between">
+        <span>
+          Showing{' '}
+          <span className="font-medium text-[var(--fg)]">{filteredMembers.length}</span>{' '}
+          of {metricCounts.total ?? baseFilteredMembers.length} team members
+        </span>
+        {activeMetric !== 'total' && (
+          <button
+            type="button"
+            onClick={() => setActiveMetric('total')}
+            className="text-xs font-semibold text-[var(--accent-purple)] transition hover:underline"
+          >
+            Clear metric filter
+          </button>
+        )}
+      </div>
+
+      {filteredMembers.length > 0 ? (
+        <div className="grid grid-cols-1 gap-6 md:grid-cols-2 xl:grid-cols-3">
+          {filteredMembers.map((member) => {
+            const initials = member.name
+              .split(' ')
+              .map((segment) => segment[0])
+              .join('');
+            const isNew = joinedWithinRange(member, activeRange);
+
+            return (
+              <Card
+                key={member.id}
+                glowOnHover
+                onClick={() => setSelectedTeamMember(member)}
+                className="p-6 text-left"
+              >
+                <div className="flex items-start justify-between gap-4">
+                  <div className="flex items-center gap-3">
+                    <div className="flex h-12 w-12 items-center justify-center rounded-full bg-gradient-primary text-lg font-semibold text-white">
+                      {initials}
+                    </div>
+                    <div>
+                      <h3 className="text-lg font-semibold text-[var(--fg)]">{member.name}</h3>
+                      <p className="text-sm text-[var(--fg-muted)] capitalize">{member.role}</p>
+                    </div>
+                  </div>
+                  <div className="flex flex-col items-end gap-2">
+                    <span
+                      className={`h-2.5 w-2.5 rounded-full ${
+                        member.status === 'active' ? 'bg-emerald-400' : 'bg-gray-400'
+                      }`}
+                    />
+                    {isNew && (
+                      <span className="rounded-full bg-amber-500/10 px-2 py-0.5 text-xs font-medium text-amber-600 dark:text-amber-400">
+                        New
+                      </span>
+                    )}
+                  </div>
+                </div>
+
+                <div className="mt-4 space-y-2 text-sm text-[var(--fg-muted)]">
+                  <div className="flex items-center gap-2">
+                    <Mail className="h-4 w-4" />
+                    <span className="truncate text-[var(--fg)]">{member.email}</span>
+                  </div>
+                  {member.phone && (
+                    <div className="flex items-center gap-2">
+                      <Phone className="h-4 w-4" />
+                      <span className="text-[var(--fg)]">{member.phone}</span>
+                    </div>
+                  )}
+                  {(member.city || member.state) && (
+                    <div className="flex items-center gap-2">
+                      <MapPin className="h-4 w-4" />
+                      <span className="text-[var(--fg)]">
+                        {[member.city, member.state].filter(Boolean).join(', ')}
+                      </span>
+                    </div>
+                  )}
+                </div>
+
+                <div className="mt-4 grid grid-cols-2 gap-4 text-sm">
+                  <div>
+                    <p className="text-xs font-semibold uppercase tracking-wide text-[var(--fg-muted)]">
+                      Projects
+                    </p>
+                    <p className="mt-1 text-lg font-semibold text-[var(--fg)]">{member.projectIds.length}</p>
+                  </div>
+                  <div>
+                    <p className="text-xs font-semibold uppercase tracking-wide text-[var(--fg-muted)]">
+                      Productivity
+                    </p>
+                    <p className="mt-1 text-lg font-semibold text-[var(--fg)]">
+                      {member.analytics.monthlyProductivity}%
+                    </p>
+                  </div>
+                  <div>
+                    <p className="text-xs font-semibold uppercase tracking-wide text-[var(--fg-muted)]">
+                      Last Active
+                    </p>
+                    <p className="mt-1 text-sm text-[var(--fg)]">{formatDate(member.lastActiveAt)}</p>
+                  </div>
+                  <div>
+                    <p className="text-xs font-semibold uppercase tracking-wide text-[var(--fg-muted)]">
+                      Joined
+                    </p>
+                    <p className="mt-1 text-sm text-[var(--fg)]">{formatDate(member.createdAt)}</p>
+                  </div>
+                </div>
+
+                {member.lastAssignedAt && (
+                  <div className="mt-4 rounded-lg border border-[var(--border)] bg-[var(--surface)]/60 p-3 text-xs">
+                    <p className="font-semibold uppercase tracking-wide text-[var(--fg-muted)]">
+                      Last Assignment
+                    </p>
+                    <p className="mt-1 text-sm text-[var(--fg)]">{formatDate(member.lastAssignedAt)}</p>
+                  </div>
+                )}
+
+                {member.skills.length > 0 && (
+                  <div className="mt-4 flex flex-wrap gap-2">
+                    {member.skills.slice(0, 4).map((skill) => (
+                      <span
+                        key={skill}
+                        className="rounded-md bg-[var(--surface)] px-2 py-1 text-xs text-[var(--fg-muted)]"
+                      >
+                        {skill}
+                      </span>
+                    ))}
+                    {member.skills.length > 4 && (
+                      <span className="rounded-md bg-[var(--surface)] px-2 py-1 text-xs text-[var(--fg-muted)]">
+                        +{member.skills.length - 4} more
+                      </span>
+                    )}
+                  </div>
+                )}
+              </Card>
+            );
+          })}
+        </div>
+      ) : (
+        <div className="rounded-2xl border border-[var(--border)] bg-[var(--surface)]/60 p-12 text-center">
+          <p className="text-lg font-semibold text-[var(--fg)]">
+            {teamMembers.length === 0 ? 'No team members available yet' : 'No team members match your filters'}
+          </p>
+          <p className="mt-2 text-sm text-[var(--fg-muted)]">
+            {teamMembers.length === 0
+              ? 'Add teammates to start tracking collaboration and performance.'
+              : 'Try adjusting your search, role selection, metric, or time range to broaden the results.'}
+          </p>
+
+          {activeFilterChips.length > 0 && (
+            <div className="mt-4 flex flex-wrap justify-center gap-2">
+              {activeFilterChips.map((chip) => (
+                <span
+                  key={chip}
+                  className="rounded-full border border-dashed border-[var(--border)] bg-[var(--surface)] px-3 py-1 text-xs text-[var(--fg-muted)]"
+                >
+                  {chip}
+                </span>
+              ))}
+            </div>
+          )}
+
+          <button
+            type="button"
+            className="mt-6 inline-flex items-center gap-2 rounded-lg bg-gradient-to-r from-[var(--accent-orange)] via-[var(--accent-pink)] to-[var(--accent-purple)] px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:opacity-90"
+          >
+            <Plus className="h-4 w-4" />
+            Add Team Member
           </button>
         </div>
       )}
 
-      {/* Team Member Modal */}
       {selectedTeamMember && (
         <TeamMemberModal
           member={selectedTeamMember}


### PR DESCRIPTION
## Summary
- extend the team member type and mock data with creation/update/activity timestamps so hooks can reason about "new" and recently engaged teammates
- refactor the team view to mirror the project/client controls, exposing search, time range chips, interactive metric cards, and cards that surface the new timeline data
- surface the additional timeline details inside the team member modal with date helpers so the enriched fields are visible everywhere they are consumed

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d0d912ab24832d949f8a4098a4ec53