### PR TITLE
Refactor gradient buttons and adjust layout spacing

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -74,7 +74,7 @@ const AppContent: React.FC = () => {
       <div className="flex-1 flex">
         <Sidebar activeView={activeView} availablePages={availablePages} onViewChange={setActiveView} />
         <div className="flex-1 flex flex-col">
-          <main className="flex-1 p-6 overflow-auto">
+          <main className="flex-1 overflow-auto px-6 py-8 sm:px-8 sm:py-10 lg:px-12 lg:py-12">
             <ActiveViewComponent />
           </main>
         </div>

--- a/src/components/Auth/LoginForm.tsx
+++ b/src/components/Auth/LoginForm.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import { Eye, EyeOff } from 'lucide-react';
+import { Button } from '../Shared/Button';
 import { useAuth } from '../../hooks/useAuth';
 
 const demoAccounts = [
@@ -104,13 +105,15 @@ const LoginForm: React.FC = () => {
               </div>
             )}
 
-            <button
+            <Button
               type="submit"
+              size="lg"
+              variant="gradient"
               disabled={isLoading}
-              className="w-full bg-gradient-primary text-white font-semibold py-3 px-4 rounded-lg hover:opacity-90 focus:outline-none focus:ring-2 focus:ring-sunset-purple focus:ring-offset-2 focus:ring-offset-[var(--bg-start)] transition-all disabled:opacity-50 disabled:cursor-not-allowed"
+              className="w-full px-4 py-3 font-semibold focus-visible:ring-offset-[var(--bg-start)]"
             >
               {isLoading ? 'Signing In...' : 'Sign In'}
-            </button>
+            </Button>
           </form>
 
           <div className="mt-8 space-y-4">

--- a/src/components/Clients/ClientDetails.tsx
+++ b/src/components/Clients/ClientDetails.tsx
@@ -880,14 +880,16 @@ const ClientDetails: React.FC<ClientDetailsProps> = ({
             <div className="flex items-center justify-between mb-4">
               <h2 className="text-xl font-bold text-gray-900 dark:text-white">{selectedProposal.title}</h2>
               <div className="flex items-center gap-2">
-                <button
+                <Button
                   type="button"
+                  size="sm"
+                  variant="gradient"
                   onClick={() => openEditProposalModal(selectedProposal)}
                   disabled={isReadOnlyMode}
-                  className="px-3 py-1.5 rounded-lg bg-gradient-primary text-white text-sm font-semibold hover:opacity-90 transition-opacity disabled:opacity-50 disabled:cursor-not-allowed"
+                  className="px-3 py-1.5 text-sm font-semibold"
                 >
                   Edit
-                </button>
+                </Button>
                 <button
                   onClick={() => setSelectedProposal(null)}
                   className="p-2 text-gray-600 dark:text-gray-300 hover:text-gray-900 dark:hover:text-white transition-colors rounded-lg hover:bg-white/20 dark:hover:bg-white/10"

--- a/src/components/Layout/AccountModal.tsx
+++ b/src/components/Layout/AccountModal.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import { X, User, Building2, Save, Edit3 } from 'lucide-react';
+import { Button } from '../Shared/Button';
 import { User as UserType, Account } from '../../types';
 
 interface AccountModalProps {
@@ -178,13 +179,15 @@ const AccountModal: React.FC<AccountModalProps> = ({ user, account, onClose }) =
               >
                 Cancel
               </button>
-              <button
+              <Button
+                type="button"
+                variant="gradient"
                 onClick={handleSave}
-                className="px-4 py-2 bg-gradient-primary text-white rounded-lg hover:opacity-90 transition-opacity flex items-center space-x-2"
+                className="px-4 py-2 gap-2"
               >
                 <Save className="w-4 h-4" />
                 <span>Save Changes</span>
-              </button>
+              </Button>
             </div>
           )}
         </div>

--- a/src/components/Projects/ProjectModal.tsx
+++ b/src/components/Projects/ProjectModal.tsx
@@ -6,6 +6,7 @@ import { useTeam } from '../../hooks/useTeam';
 import { useAuth } from '../../hooks/useAuth';
 import TeamMemberModal from '../Clients/TeamMemberModal';
 import ClientModal from './ClientModal';
+import { Button } from '../Shared/Button';
 
 interface ProjectModalProps {
   project: Project;
@@ -165,9 +166,14 @@ const ProjectModal: React.FC<ProjectModalProps> = ({ project, onClose }) => {
               <div className="bg-white/20 dark:bg-white/10 border border-white/20 dark:border-white/10 rounded-xl p-6 backdrop-blur-sm">
                 <h4 className="text-lg font-semibold text-gray-900 dark:text-white mb-4">Quick Actions</h4>
                 <div className="space-y-3">
-                  <button className="w-full bg-gradient-primary text-white font-semibold py-2 px-4 rounded-lg hover:opacity-90 transition-opacity">
+                  <Button
+                    type="button"
+                    size="sm"
+                    variant="gradient"
+                    className="w-full px-4 py-2 font-semibold"
+                  >
                     Add System
-                  </button>
+                  </Button>
                   <button className="w-full bg-white/30 dark:bg-white/10 text-gray-900 dark:text-white font-semibold py-2 px-4 rounded-lg hover:bg-white/40 dark:hover:bg-white/15 transition-colors backdrop-blur-sm">
                     Edit Project
                   </button>

--- a/src/components/Shared/Button.tsx
+++ b/src/components/Shared/Button.tsx
@@ -1,14 +1,11 @@
 import React from 'react';
 
-interface ButtonProps {
+interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
   children: React.ReactNode;
-  variant?: 'primary' | 'secondary' | 'ghost' | 'outline';
-  size?: 'sm' | 'md' | 'lg';
+  variant?: 'primary' | 'secondary' | 'ghost' | 'outline' | 'gradient';
+  size?: 'xs' | 'sm' | 'md' | 'lg';
   className?: string;
-  onClick?: () => void;
   href?: string;
-  disabled?: boolean;
-  type?: 'button' | 'submit' | 'reset';
   glowOnHover?: boolean;
   activeGlow?: boolean;
 }
@@ -18,55 +15,66 @@ export function Button({
   variant = 'primary',
   size = 'md',
   className = '',
-  onClick,
   href,
   disabled = false,
   type = 'button',
   glowOnHover = false,
   activeGlow = false,
+  onClick,
+  ...rest
 }: ButtonProps) {
-  const baseClasses = 'inline-flex items-center justify-center font-medium rounded-lg transition-all duration-200 focus:outline-none focus:ring-2 focus:ring-offset-2';
-  
+  const baseClasses = 'inline-flex items-center justify-center font-medium rounded-lg transition-all duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2';
+
   const variantClasses = {
-    primary: 'bg-[var(--card)] text-[var(--fg)] focus:ring-[var(--accent-orange)] shadow-sm',
-    secondary: 'bg-[var(--card)] text-[var(--fg)] focus:ring-[var(--accent-mid)] shadow-sm',
-    ghost: 'text-[var(--fg-muted)] focus:ring-[var(--accent-mid)] hover:bg-[var(--card)] shadow-sm',
-    outline: 'border border-[var(--border)] text-[var(--fg)] focus:ring-[var(--accent-mid)] hover:bg-[var(--card)] shadow-sm'
+    primary: 'bg-[var(--card)] text-[var(--fg)] focus-visible:ring-[var(--accent-orange)] shadow-sm',
+    secondary: 'bg-[var(--card)] text-[var(--fg)] focus-visible:ring-[var(--accent-mid)] shadow-sm',
+    ghost: 'text-[var(--fg-muted)] focus-visible:ring-[var(--accent-mid)] hover:bg-[var(--card)] shadow-sm',
+    outline: 'border border-[var(--border)] text-[var(--fg)] focus-visible:ring-[var(--accent-mid)] hover:bg-[var(--card)] shadow-sm',
+    gradient:
+      'bg-gradient-to-r from-[var(--accent-orange)] via-[var(--accent-pink)] to-[var(--accent-purple)] text-white shadow-sm focus-visible:ring-[var(--accent-purple)] focus-visible:ring-offset-[var(--surface)] hover:opacity-90'
   };
-  
+
   const sizeClasses = {
+    xs: 'px-2.5 py-1 text-xs',
     sm: 'px-3 py-1.5 text-sm',
     md: 'px-4 py-2 text-sm',
     lg: 'px-6 py-3 text-base'
   };
-  
+
   const disabledClasses = disabled 
     ? 'opacity-50 cursor-not-allowed' 
     : '';
   
-  const buttonClasses = `${baseClasses} ${variantClasses[variant]} ${sizeClasses[size]} ${disabledClasses} relative z-10`;
-  
+  const buttonClasses = `${baseClasses} ${variantClasses[variant]} ${sizeClasses[size]} ${disabledClasses} relative z-10 ${className}`;
+  const wrapperClasses = className ? `relative group ${className}` : 'relative group';
+
   if (glowOnHover || activeGlow) {
     if (href) {
       return (
-        <div className={`relative group ${className}`}>
-          <div 
+        <div className={wrapperClasses}>
+          <div
             className={`absolute -inset-0.5 bg-gradient-to-r from-[var(--accent-orange)] via-[var(--accent-pink)] to-[var(--accent-purple)] rounded-lg transition-opacity duration-300 z-0 ${
               activeGlow ? 'opacity-100' : glowOnHover ? 'opacity-0 group-hover:opacity-100' : 'opacity-0'
             }`}
             style={{ filter: 'blur(2px)' }}
             aria-hidden="true"
           />
-          <a href={href} className={buttonClasses}>
+          <a
+            href={disabled ? undefined : href}
+            aria-disabled={disabled}
+            className={`${buttonClasses} ${disabled ? 'pointer-events-none' : ''}`}
+            onClick={onClick}
+            {...rest}
+          >
             {children}
           </a>
         </div>
       );
     }
-    
+
     return (
-      <div className={`relative group ${className}`}>
-        <div 
+      <div className={wrapperClasses}>
+        <div
           className={`absolute -inset-0.5 bg-gradient-to-r from-[var(--accent-orange)] via-[var(--accent-pink)] to-[var(--accent-purple)] rounded-lg transition-opacity duration-300 z-0 ${
             activeGlow ? 'opacity-75' : glowOnHover ? 'opacity-0 group-hover:opacity-75' : 'opacity-0'
           }`}
@@ -78,6 +86,7 @@ export function Button({
           onClick={onClick}
           disabled={disabled}
           className={buttonClasses}
+          {...rest}
         >
           {children}
         </button>
@@ -88,18 +97,25 @@ export function Button({
   // No glow version
   if (href) {
     return (
-      <a href={href} className={`${buttonClasses} ${className}`}>
+      <a
+        href={disabled ? undefined : href}
+        aria-disabled={disabled}
+        className={`${buttonClasses} ${disabled ? 'pointer-events-none' : ''}`}
+        onClick={onClick}
+        {...rest}
+      >
         {children}
       </a>
     );
   }
-  
+
   return (
     <button
       type={type}
       onClick={onClick}
       disabled={disabled}
-      className={`${buttonClasses} ${className}`}
+      className={buttonClasses}
+      {...rest}
     >
       {children}
     </button>

--- a/src/components/Shared/EntityFormModal.tsx
+++ b/src/components/Shared/EntityFormModal.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useMemo, useState } from 'react';
 import { X, Building2, FolderOpen, Users, Wrench, Save, Sparkles, FileSignature } from 'lucide-react';
 import { Client, ClientProposal, Project, TeamMember } from '../../types';
 import { Tool } from '../../types/tools';
+import { Button } from './Button';
 
 export type EntityType = 'client' | 'project' | 'team' | 'tool' | 'proposal';
 export type FormMode = 'create' | 'edit';
@@ -234,20 +235,22 @@ const ClientForm: React.FC<ClientFormProps> = ({ mode, initialData, onSubmit, on
       </Section>
 
       <div className="flex items-center justify-end gap-3">
-        <button
+        <Button
           type="button"
+          variant="outline"
           onClick={onCancel}
-          className="px-4 py-2 rounded-lg border border-[var(--border)] text-[var(--fg)] hover:bg-[var(--surface)] transition"
+          className="px-4 py-2 hover:bg-[var(--surface)]"
         >
           Cancel
-        </button>
-        <button
+        </Button>
+        <Button
           type="submit"
-          className="px-4 py-2 rounded-lg bg-gradient-to-r from-[var(--accent-orange)] via-[var(--accent-pink)] to-[var(--accent-purple)] text-white font-semibold flex items-center gap-2"
+          variant="gradient"
+          className="px-4 py-2 font-semibold gap-2"
         >
           <Save className="w-4 h-4" />
           {mode === 'create' ? 'Add Client' : 'Save Changes'}
-        </button>
+        </Button>
       </div>
     </form>
   );
@@ -356,20 +359,22 @@ const ProjectForm: React.FC<ProjectFormProps> = ({ mode, initialData, clients, t
       </Section>
 
       <div className="flex items-center justify-end gap-3">
-        <button
+        <Button
           type="button"
+          variant="outline"
           onClick={onCancel}
-          className="px-4 py-2 rounded-lg border border-[var(--border)] text-[var(--fg)] hover:bg-[var(--surface)] transition"
+          className="px-4 py-2 hover:bg-[var(--surface)]"
         >
           Cancel
-        </button>
-        <button
+        </Button>
+        <Button
           type="submit"
-          className="px-4 py-2 rounded-lg bg-gradient-to-r from-[var(--accent-orange)] via-[var(--accent-pink)] to-[var(--accent-purple)] text-white font-semibold flex items-center gap-2"
+          variant="gradient"
+          className="px-4 py-2 font-semibold gap-2"
         >
           <Save className="w-4 h-4" />
           {mode === 'create' ? 'Add Project' : 'Save Changes'}
-        </button>
+        </Button>
       </div>
     </form>
   );
@@ -501,20 +506,22 @@ const TeamForm: React.FC<TeamFormProps> = ({ mode, initialData, onSubmit, onCanc
       </Section>
 
       <div className="flex items-center justify-end gap-3">
-        <button
+        <Button
           type="button"
+          variant="outline"
           onClick={onCancel}
-          className="px-4 py-2 rounded-lg border border-[var(--border)] text-[var(--fg)] hover:bg-[var(--surface)] transition"
+          className="px-4 py-2 hover:bg-[var(--surface)]"
         >
           Cancel
-        </button>
-        <button
+        </Button>
+        <Button
           type="submit"
-          className="px-4 py-2 rounded-lg bg-gradient-to-r from-[var(--accent-orange)] via-[var(--accent-pink)] to-[var(--accent-purple)] text-white font-semibold flex items-center gap-2"
+          variant="gradient"
+          className="px-4 py-2 font-semibold gap-2"
         >
           <Save className="w-4 h-4" />
           {mode === 'create' ? 'Add Team Member' : 'Save Changes'}
-        </button>
+        </Button>
       </div>
     </form>
   );
@@ -791,20 +798,22 @@ const ToolForm: React.FC<ToolFormProps> = ({ mode, initialData, clients, project
       </Section>
 
       <div className="flex items-center justify-end gap-3">
-        <button
+        <Button
           type="button"
+          variant="outline"
           onClick={onCancel}
-          className="px-4 py-2 rounded-lg border border-[var(--border)] text-[var(--fg)] hover:bg-[var(--surface)] transition"
+          className="px-4 py-2 hover:bg-[var(--surface)]"
         >
           Cancel
-        </button>
-        <button
+        </Button>
+        <Button
           type="submit"
-          className="px-4 py-2 rounded-lg bg-gradient-to-r from-[var(--accent-orange)] via-[var(--accent-pink)] to-[var(--accent-purple)] text-white font-semibold flex items-center gap-2"
+          variant="gradient"
+          className="px-4 py-2 font-semibold gap-2"
         >
           <Sparkles className="w-4 h-4" />
           {mode === 'create' ? 'Create Tool' : 'Save Changes'}
-        </button>
+        </Button>
       </div>
     </form>
   );
@@ -933,20 +942,22 @@ const ProposalForm: React.FC<ProposalFormProps> = ({ mode, initialData, onSubmit
       </Section>
 
       <div className="flex items-center justify-end gap-3">
-        <button
+        <Button
           type="button"
+          variant="outline"
           onClick={onCancel}
-          className="px-4 py-2 rounded-lg border border-[var(--border)] text-[var(--fg)] hover:bg-[var(--surface)] transition"
+          className="px-4 py-2 hover:bg-[var(--surface)]"
         >
           Cancel
-        </button>
-        <button
+        </Button>
+        <Button
           type="submit"
-          className="px-4 py-2 rounded-lg bg-gradient-to-r from-[var(--accent-orange)] via-[var(--accent-pink)] to-[var(--accent-purple)] text-white font-semibold flex items-center gap-2"
+          variant="gradient"
+          className="px-4 py-2 font-semibold gap-2"
         >
           <Save className="w-4 h-4" />
           {mode === 'create' ? 'Create Proposal' : 'Save Changes'}
-        </button>
+        </Button>
       </div>
     </form>
   );

--- a/src/views/Clients.tsx
+++ b/src/views/Clients.tsx
@@ -15,6 +15,7 @@ import {
 import ClientCard from '../components/Clients/ClientCard';
 import ClientDetails from '../components/Clients/ClientDetails';
 import { Card } from '../components/Shared/Card';
+import { Button } from '../components/Shared/Button';
 import { EntityFormModal, ClientFormValues, FormMode } from '../components/Shared/EntityFormModal';
 import { useClients } from '../hooks/useClients';
 import { useAuth } from '../hooks/useAuth';
@@ -406,19 +407,21 @@ const Clients: React.FC = () => {
                     {timeRangeOptions.map((option) => {
                       const isActive = option.value === timeRange;
                       return (
-                        <button
+                        <Button
                           key={option.value}
                           type="button"
+                          size="xs"
+                          variant={isActive ? 'gradient' : 'outline'}
                           onClick={() => handleTimeRangeChange(option.value)}
                           aria-pressed={isActive}
-                          className={`rounded-full border px-3 py-1.5 text-xs font-medium transition focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent-purple)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--card)] ${
+                          className={`rounded-full px-3 py-1.5 text-xs font-medium focus-visible:ring-[var(--accent-purple)] focus-visible:ring-offset-[var(--card)] ${
                             isActive
-                              ? 'border-transparent bg-gradient-to-r from-[var(--accent-orange)] via-[var(--accent-pink)] to-[var(--accent-purple)] text-white shadow-sm'
-                              : 'border-[var(--border)] bg-[var(--surface)] text-[var(--fg-muted)] hover:text-[var(--fg)]'
+                              ? ''
+                              : 'bg-[var(--surface)] text-[var(--fg-muted)] hover:bg-[var(--surface)] hover:text-[var(--fg)]'
                           }`}
                         >
                           {option.label}
-                        </button>
+                        </Button>
                       );
                     })}
                   </div>
@@ -442,14 +445,16 @@ const Clients: React.FC = () => {
                   </select>
                 </div>
 
-                <button
+                <Button
                   type="button"
+                  size="sm"
+                  variant="gradient"
                   onClick={openCreateClientModal}
-                  className="flex items-center gap-2 rounded-lg bg-gradient-to-r from-[var(--accent-orange)] via-[var(--accent-pink)] to-[var(--accent-purple)] px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:opacity-90"
+                  className="gap-2 px-4 py-2 text-sm font-semibold"
                 >
                   <Plus className="h-4 w-4" />
                   New Client
-                </button>
+                </Button>
               </div>
             </div>
           </div>
@@ -560,14 +565,16 @@ const Clients: React.FC = () => {
                   : 'Try adjusting your search, filters, or metric selection.'}
               </p>
               <div className="mt-6 flex justify-center">
-                <button
+                <Button
                   type="button"
+                  size="sm"
+                  variant="gradient"
                   onClick={openCreateClientModal}
-                  className="flex items-center gap-2 rounded-lg bg-gradient-to-r from-[var(--accent-orange)] via-[var(--accent-pink)] to-[var(--accent-purple)] px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:opacity-90"
+                  className="gap-2 px-4 py-2 text-sm font-semibold"
                 >
                   <Plus className="h-4 w-4" />
                   Add Client
-                </button>
+                </Button>
               </div>
             </div>
           )}

--- a/src/views/Projects.tsx
+++ b/src/views/Projects.tsx
@@ -13,6 +13,7 @@ import {
 import ProjectCard from '../components/Projects/ProjectCard';
 import ProjectModal from '../components/Projects/ProjectModal';
 import { Card } from '../components/Shared/Card';
+import { Button } from '../components/Shared/Button';
 import { useProjects } from '../hooks/useProjects';
 import { Project } from '../types';
 import {
@@ -240,19 +241,21 @@ const Projects: React.FC = () => {
                 {timeRangeOptions.map((option) => {
                   const isActive = option.value === timeRange;
                   return (
-                    <button
+                    <Button
                       key={option.value}
                       type="button"
+                      size="xs"
+                      variant={isActive ? 'gradient' : 'outline'}
                       onClick={() => setTimeRange(option.value)}
                       aria-pressed={isActive}
-                      className={`rounded-full border px-3 py-1.5 text-xs font-medium transition focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent-purple)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--card)] ${
+                      className={`rounded-full px-3 py-1.5 text-xs font-medium focus-visible:ring-[var(--accent-purple)] focus-visible:ring-offset-[var(--card)] ${
                         isActive
-                          ? 'border-transparent bg-gradient-to-r from-[var(--accent-orange)] via-[var(--accent-pink)] to-[var(--accent-purple)] text-white shadow-sm'
-                          : 'border-[var(--border)] bg-[var(--surface)] text-[var(--fg-muted)] hover:text-[var(--fg)]'
+                          ? ''
+                          : 'bg-[var(--surface)] text-[var(--fg-muted)] hover:bg-[var(--surface)] hover:text-[var(--fg)]'
                       }`}
                     >
                       {option.label}
-                    </button>
+                    </Button>
                   );
                 })}
               </div>
@@ -276,13 +279,15 @@ const Projects: React.FC = () => {
               </select>
             </div>
 
-            <button
+            <Button
               type="button"
-              className="flex items-center gap-2 rounded-lg bg-gradient-to-r from-[var(--accent-orange)] via-[var(--accent-pink)] to-[var(--accent-purple)] px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:opacity-90"
+              size="sm"
+              variant="gradient"
+              className="gap-2 px-4 py-2 text-sm font-semibold"
             >
               <Plus className="h-4 w-4" />
               New Project
-            </button>
+            </Button>
           </div>
         </div>
       </div>
@@ -386,13 +391,15 @@ const Projects: React.FC = () => {
             </div>
           )}
 
-          <button
+          <Button
             type="button"
-            className="mt-6 inline-flex items-center gap-2 rounded-lg bg-gradient-to-r from-[var(--accent-orange)] via-[var(--accent-pink)] to-[var(--accent-purple)] px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:opacity-90"
+            size="sm"
+            variant="gradient"
+            className="mt-6 inline-flex gap-2 px-4 py-2 text-sm font-semibold"
           >
             <Plus className="h-4 w-4" />
             New Project
-          </button>
+          </Button>
         </div>
       )}
 

--- a/src/views/Team.tsx
+++ b/src/views/Team.tsx
@@ -15,6 +15,7 @@ import {
 } from 'lucide-react';
 import TeamMemberModal from '../components/Clients/TeamMemberModal';
 import { Card } from '../components/Shared/Card';
+import { Button } from '../components/Shared/Button';
 import { useTeam } from '../hooks/useTeam';
 import type { TeamMember } from '../types';
 import {
@@ -284,19 +285,21 @@ const Team: React.FC = () => {
                 {timeRangeOptions.map((option) => {
                   const isActive = option.value === timeRange;
                   return (
-                    <button
+                    <Button
                       key={option.value}
                       type="button"
+                      size="xs"
+                      variant={isActive ? 'gradient' : 'outline'}
                       onClick={() => setTimeRange(option.value)}
                       aria-pressed={isActive}
-                      className={`rounded-full border px-3 py-1.5 text-xs font-medium transition focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent-purple)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--card)] ${
+                      className={`rounded-full px-3 py-1.5 text-xs font-medium focus-visible:ring-[var(--accent-purple)] focus-visible:ring-offset-[var(--card)] ${
                         isActive
-                          ? 'border-transparent bg-gradient-to-r from-[var(--accent-orange)] via-[var(--accent-pink)] to-[var(--accent-purple)] text-white shadow-sm'
-                          : 'border-[var(--border)] bg-[var(--surface)] text-[var(--fg-muted)] hover:text-[var(--fg)]'
+                          ? ''
+                          : 'bg-[var(--surface)] text-[var(--fg-muted)] hover:bg-[var(--surface)] hover:text-[var(--fg)]'
                       }`}
                     >
                       {option.label}
-                    </button>
+                    </Button>
                   );
                 })}
               </div>
@@ -320,13 +323,15 @@ const Team: React.FC = () => {
               </select>
             </div>
 
-            <button
+            <Button
               type="button"
-              className="flex items-center gap-2 rounded-lg bg-gradient-to-r from-[var(--accent-orange)] via-[var(--accent-pink)] to-[var(--accent-purple)] px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:opacity-90"
+              size="sm"
+              variant="gradient"
+              className="gap-2 px-4 py-2 text-sm font-semibold"
             >
               <Plus className="h-4 w-4" />
               Add Team Member
-            </button>
+            </Button>
           </div>
         </div>
       </div>
@@ -540,13 +545,15 @@ const Team: React.FC = () => {
             </div>
           )}
 
-          <button
+          <Button
             type="button"
-            className="mt-6 inline-flex items-center gap-2 rounded-lg bg-gradient-to-r from-[var(--accent-orange)] via-[var(--accent-pink)] to-[var(--accent-purple)] px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:opacity-90"
+            size="sm"
+            variant="gradient"
+            className="mt-6 inline-flex gap-2 px-4 py-2 text-sm font-semibold"
           >
             <Plus className="h-4 w-4" />
             Add Team Member
-          </button>
+          </Button>
         </div>
       )}
 

--- a/src/views/Workspaces.tsx
+++ b/src/views/Workspaces.tsx
@@ -6,6 +6,7 @@ import { useTeam } from '../hooks/useTeam';
 import { useAuth } from '../hooks/useAuth';
 import WorkspaceCard, { WorkspaceCardData } from '../components/Workspaces/WorkspaceCard';
 import { EntityFormModal, EntityFormValues, ClientFormValues, ProjectFormValues, TeamFormValues } from '../components/Shared/EntityFormModal';
+import { Button } from '../components/Shared/Button';
 import { Client, Project, TeamMember } from '../types';
 
 const typeOrder = ['client', 'project', 'team'] as const;
@@ -255,18 +256,21 @@ const Workspaces: React.FC = () => {
               {typeOrder.map((type) => {
                 const isActive = activeTypes.includes(type);
                 return (
-                  <button
+                  <Button
                     key={type}
                     type="button"
+                    size="sm"
+                    variant={isActive ? 'gradient' : 'outline'}
                     onClick={() => toggleType(type)}
-                    className={`rounded-lg border px-3 py-2 text-sm font-medium transition ${
+                    aria-pressed={isActive}
+                    className={`rounded-lg py-2 text-sm font-medium ${
                       isActive
-                        ? 'border-transparent bg-gradient-to-r from-[var(--accent-orange)] via-[var(--accent-pink)] to-[var(--accent-purple)] text-white'
-                        : 'border-[var(--border)] bg-[var(--surface)] text-[var(--fg-muted)] hover:text-[var(--fg)]'
+                        ? ''
+                        : 'bg-[var(--surface)] text-[var(--fg-muted)] hover:bg-[var(--surface)] hover:text-[var(--fg)]'
                     }`}
                   >
                     {typeLabels[type]}
-                  </button>
+                  </Button>
                 );
               })}
             </div>
@@ -300,14 +304,16 @@ const Workspaces: React.FC = () => {
                     </option>
                   ))}
                 </select>
-                <button
+                <Button
                   type="button"
+                  size="sm"
+                  variant="gradient"
                   onClick={() => setFormState({ type: createType, mode: 'create' })}
-                  className="flex items-center gap-2 rounded-lg bg-gradient-to-r from-[var(--accent-orange)] via-[var(--accent-pink)] to-[var(--accent-purple)] px-4 py-2 text-sm font-semibold text-white shadow-sm"
+                  className="gap-2 px-4 py-2 text-sm font-semibold"
                 >
                   <PlusCircle className="h-4 w-4" />
                   Add {typeLabels[createType]}
-                </button>
+                </Button>
               </div>
             </div>
           </div>


### PR DESCRIPTION
## Summary
- extend the shared Button component with a gradient variant, an extra-small size option, and consistent focus handling for glow states
- replace remaining gradient call-to-action buttons in workspace, project, client, team flows and shared forms with the updated Button styling
- update the main content wrapper padding to align with the new spacing scale from the design guidance

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d14b7f7ae8832d985d0dcb9730b11d