### PR TITLE
Add timeout cleanup in useTeam hook

### DIFF
--- a/src/hooks/useTeam.ts
+++ b/src/hooks/useTeam.ts
@@ -385,10 +385,10 @@ export const useTeam = () => {
 
   useEffect(() => {
     // Simulate API call
-    setTimeout(() => {
+    const timeoutId = setTimeout(() => {
       // Filter team members based on user's account and projects
       let filteredMembers = mockTeamMembers;
-      
+
       if (user?.accountType === 'business') {
         // For business accounts, show team members who work on business projects
         filteredMembers = mockTeamMembers.filter(member =>
@@ -400,6 +400,10 @@ export const useTeam = () => {
       setTeamMembers(filteredMembers);
       setIsLoading(false);
     }, 500);
+
+    return () => {
+      clearTimeout(timeoutId);
+    };
   }, [user, account]);
 
   const getTeamMembersByIds = (ids: string[]): TeamMember[] => {


### PR DESCRIPTION
## Summary
- store the simulated fetch timeout handle inside the useTeam effect
- clear the timeout during cleanup to avoid updates after unmounting

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d155a10c14832d89a2cc0999bfeeed