### PR TITLE
Make Card accessible when clickable

### DIFF
--- a/src/components/Shared/Card.tsx
+++ b/src/components/Shared/Card.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-interface CardProps {
+interface CardProps extends React.AriaAttributes {
   children: React.ReactNode;
   className?: string;
   glowOnHover?: boolean;
@@ -8,28 +8,77 @@ interface CardProps {
   onClick?: () => void;
 }
 
-export function Card({ 
-  children, 
-  className = "", 
-  glowOnHover = false, 
+export function Card({
+  children,
+  className = "",
+  glowOnHover = false,
   activeGlow = false,
-  onClick 
+  onClick,
+  ...ariaProps
 }: CardProps) {
+  const isInteractive = typeof onClick === 'function';
+
+  const interactiveClasses = isInteractive
+    ? 'cursor-pointer rounded-xl focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent-pink)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--card)]'
+    : '';
+
+  const handleKeyDown: React.KeyboardEventHandler<HTMLDivElement> = (event) => {
+    if (!onClick) return;
+
+    if (event.key === 'Enter') {
+      event.preventDefault();
+      onClick();
+    }
+
+    if (event.key === ' ' || event.key === 'Spacebar') {
+      event.preventDefault();
+    }
+  };
+
+  const handleKeyUp: React.KeyboardEventHandler<HTMLDivElement> = (event) => {
+    if (!onClick) return;
+
+    if (event.key === ' ' || event.key === 'Spacebar') {
+      event.preventDefault();
+      onClick();
+    }
+  };
+
+  const interactiveProps = isInteractive
+    ? {
+        role: 'button' as const,
+        tabIndex: 0,
+        onClick,
+        onKeyDown: handleKeyDown,
+        onKeyUp: handleKeyUp
+      }
+    : {};
+
   if (glowOnHover || activeGlow) {
     return (
-      <div className={`relative group ${onClick ? 'cursor-pointer' : ''}`} onClick={onClick}>
-        <div 
+      <div
+        className={`relative group ${interactiveClasses}`}
+        {...interactiveProps}
+        {...ariaProps}
+      >
+        <div
           className={`absolute -inset-0.5 bg-gradient-to-r from-[var(--accent-orange)] via-[var(--accent-pink)] to-[var(--accent-purple)] rounded-xl transition-opacity duration-300 z-0 ${
-            activeGlow ? 'opacity-75' : glowOnHover ? 'opacity-0 group-hover:opacity-75' : 'opacity-0'
+            activeGlow
+              ? 'opacity-75'
+              : glowOnHover
+                ? 'opacity-0 group-hover:opacity-75 group-focus:opacity-75 group-focus-visible:opacity-75'
+                : 'opacity-0'
           }`}
           style={{ filter: 'blur(2px)' }}
           aria-hidden="true"
         />
-        <div className={`
+        <div
+          className={`
           relative z-10 h-full rounded-xl border border-[var(--border)] transition-all duration-300
           bg-[var(--card)] shadow-sm
           ${className}
-        `}>
+        `}
+        >
           {children}
         </div>
       </div>
@@ -37,12 +86,16 @@ export function Card({
   }
 
   return (
-    <div className={`
+    <div
+      className={`
       h-full rounded-xl border border-[var(--border)] transition-all duration-300
       bg-[var(--card)] shadow-sm
-      ${onClick ? 'cursor-pointer' : ''}
+      ${interactiveClasses}
       ${className}
-    `} onClick={onClick}>
+    `}
+      {...interactiveProps}
+      {...ariaProps}
+    >
       {children}
     </div>
   );


### PR DESCRIPTION
## Summary
- render clickable cards as focusable controls with keyboard handlers while keeping the gradient glow
- forward aria attributes to the interactive wrapper so assistive tech metadata is preserved

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d15de15de4832d80b4680f8ed5b5b0