### PR TITLE
Revamp systems hub layout

### DIFF
--- a/src/components/Solutions/MarketplaceFormModal.tsx
+++ b/src/components/Solutions/MarketplaceFormModal.tsx
@@ -1,0 +1,236 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import { ShoppingBag, X } from 'lucide-react';
+import { Button } from '../Shared/Button';
+import type { Client } from '../../types';
+
+export interface MarketplaceFormValues {
+  itemId?: string;
+  clientId: string;
+  name: string;
+  type: string;
+  category: string;
+  description?: string;
+  downloads?: number;
+  rating?: number;
+}
+
+interface MarketplaceFormModalProps {
+  isOpen: boolean;
+  mode: 'create' | 'edit';
+  clients: Client[];
+  initialValues?: MarketplaceFormValues;
+  onClose: () => void;
+  onSubmit: (values: MarketplaceFormValues) => void;
+}
+
+const inputClassName =
+  'w-full rounded-lg border border-[var(--border)] bg-[var(--surface)] px-3 py-2 text-sm text-[var(--fg)] focus:outline-none focus:ring-2 focus:ring-[var(--accent-purple)] focus:border-transparent transition';
+
+const labelClassName = 'text-xs font-medium uppercase tracking-wide text-[var(--fg-muted)]';
+
+const MarketplaceFormModal: React.FC<MarketplaceFormModalProps> = ({
+  isOpen,
+  mode,
+  clients,
+  initialValues,
+  onClose,
+  onSubmit,
+}) => {
+  const defaultClientId = useMemo(() => initialValues?.clientId || clients[0]?.id || '', [clients, initialValues?.clientId]);
+
+  const [formValues, setFormValues] = useState<MarketplaceFormValues>({
+    itemId: initialValues?.itemId,
+    clientId: defaultClientId,
+    name: initialValues?.name || '',
+    type: initialValues?.type || 'template',
+    category: initialValues?.category || '',
+    description: initialValues?.description || '',
+    downloads: initialValues?.downloads ?? 0,
+    rating: initialValues?.rating ?? 5,
+  });
+
+  useEffect(() => {
+    if (!isOpen) {
+      return;
+    }
+
+    setFormValues({
+      itemId: initialValues?.itemId,
+      clientId: initialValues?.clientId || clients[0]?.id || '',
+      name: initialValues?.name || '',
+      type: initialValues?.type || 'template',
+      category: initialValues?.category || '',
+      description: initialValues?.description || '',
+      downloads: initialValues?.downloads ?? 0,
+      rating: initialValues?.rating ?? 5,
+    });
+  }, [clients, initialValues, isOpen]);
+
+  if (!isOpen) {
+    return null;
+  }
+
+  const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!formValues.clientId) {
+      return;
+    }
+
+    onSubmit({
+      ...formValues,
+      description: formValues.description?.trim() || undefined,
+      downloads: formValues.downloads ?? 0,
+      rating: formValues.rating ?? 0,
+    });
+  };
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 px-4 py-6"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="marketplace-form-title"
+      onClick={onClose}
+    >
+      <div
+        className="w-full max-w-2xl overflow-hidden rounded-2xl border border-[var(--border)] bg-[var(--card)] shadow-2xl"
+        onClick={(event) => event.stopPropagation()}
+      >
+        <div className="flex items-center justify-between gap-4 border-b border-[var(--border)] bg-[var(--surface)]/70 px-6 py-4">
+          <div className="flex items-center gap-2">
+            <ShoppingBag className="h-5 w-5 text-[var(--fg-muted)]" />
+            <div>
+              <h2 id="marketplace-form-title" className="text-lg font-semibold text-[var(--fg)]">
+                {mode === 'create' ? 'Create marketplace asset' : 'Edit marketplace asset'}
+              </h2>
+              <p className="text-sm text-[var(--fg-muted)]">
+                Publish automation assets for agencies and operators to deploy.
+              </p>
+            </div>
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            className="rounded-full p-2 text-[var(--fg-muted)] transition hover:bg-[var(--surface)] hover:text-[var(--fg)]"
+            aria-label="Close marketplace form"
+          >
+            <X className="h-4 w-4" />
+          </button>
+        </div>
+
+        <form className="space-y-5 p-6" onSubmit={handleSubmit}>
+          <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+            <label className="space-y-1">
+              <span className={labelClassName}>Publisher</span>
+              <select
+                className={inputClassName}
+                value={formValues.clientId}
+                onChange={(event) =>
+                  setFormValues((prev) => ({ ...prev, clientId: event.target.value }))
+                }
+                required
+              >
+                {clients.map((client) => (
+                  <option key={client.id} value={client.id}>
+                    {client.companyName}
+                  </option>
+                ))}
+              </select>
+            </label>
+
+            <label className="space-y-1">
+              <span className={labelClassName}>Asset type</span>
+              <input
+                className={inputClassName}
+                value={formValues.type}
+                onChange={(event) =>
+                  setFormValues((prev) => ({ ...prev, type: event.target.value }))
+                }
+                placeholder="Template"
+              />
+            </label>
+
+            <label className="space-y-1">
+              <span className={labelClassName}>Title</span>
+              <input
+                className={inputClassName}
+                value={formValues.name}
+                onChange={(event) =>
+                  setFormValues((prev) => ({ ...prev, name: event.target.value }))
+                }
+                placeholder="AI onboarding workflow"
+                required
+              />
+            </label>
+
+            <label className="space-y-1">
+              <span className={labelClassName}>Category</span>
+              <input
+                className={inputClassName}
+                value={formValues.category}
+                onChange={(event) =>
+                  setFormValues((prev) => ({ ...prev, category: event.target.value }))
+                }
+                placeholder="Customer success"
+                required
+              />
+            </label>
+          </div>
+
+          <label className="space-y-1">
+            <span className={labelClassName}>Description</span>
+            <textarea
+              className={`${inputClassName} min-h-[120px]`}
+              value={formValues.description || ''}
+              onChange={(event) =>
+                setFormValues((prev) => ({ ...prev, description: event.target.value }))
+              }
+              placeholder="Share the value buyers receive when deploying this asset."
+            />
+          </label>
+
+          <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+            <label className="space-y-1">
+              <span className={labelClassName}>Downloads</span>
+              <input
+                type="number"
+                min="0"
+                className={inputClassName}
+                value={formValues.downloads ?? 0}
+                onChange={(event) =>
+                  setFormValues((prev) => ({ ...prev, downloads: Number(event.target.value) || 0 }))
+                }
+              />
+            </label>
+
+            <label className="space-y-1">
+              <span className={labelClassName}>Rating</span>
+              <input
+                type="number"
+                min="0"
+                max="5"
+                step="0.1"
+                className={inputClassName}
+                value={formValues.rating ?? 0}
+                onChange={(event) =>
+                  setFormValues((prev) => ({ ...prev, rating: Number(event.target.value) }))
+                }
+              />
+            </label>
+          </div>
+
+          <div className="flex items-center justify-end gap-3">
+            <Button type="button" variant="ghost" size="sm" onClick={onClose}>
+              Cancel
+            </Button>
+            <Button type="submit" variant="primary" size="sm" glowOnHover>
+              {mode === 'create' ? 'Create listing' : 'Save changes'}
+            </Button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+};
+
+export default MarketplaceFormModal;

--- a/src/components/Solutions/SolutionCard.tsx
+++ b/src/components/Solutions/SolutionCard.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Activity, Layers, ShoppingBag, Sparkles, Pencil, BarChart3, FileText, Lock } from 'lucide-react';
+import { Button } from '../Shared/Button';
 import { Card } from '../Shared/Card';
 
 type SolutionType = 'tool' | 'system' | 'template' | 'marketplace';
@@ -44,6 +45,8 @@ export interface SolutionAccessInfo {
 interface SolutionCardProps {
   data: SolutionCardData;
   onEdit?: (data: SolutionCardData) => void;
+  onCreateTemplate?: (data: SolutionCardData) => void;
+  onListInMarketplace?: (data: SolutionCardData) => void;
 }
 
 const typeConfig: Record<SolutionType, { label: string; icon: React.ComponentType<{ className?: string }>; badgeClass: string }> = {
@@ -89,10 +92,17 @@ const formatLabel = (value: string) =>
     .replace(/-/g, ' ')
     .replace(/\b\w/g, (char) => char.toUpperCase());
 
-export const SolutionCard: React.FC<SolutionCardProps> = ({ data, onEdit }) => {
+export const SolutionCard: React.FC<SolutionCardProps> = ({
+  data,
+  onEdit,
+  onCreateTemplate,
+  onListInMarketplace,
+}) => {
   const type = typeConfig[data.type];
   const StatusIcon = type.icon;
   const statusClass = data.status ? statusStyles[data.status] || 'border-[var(--border)] text-[var(--fg-muted)] bg-[var(--surface)]' : '';
+
+  const hasFooterActions = Boolean(onCreateTemplate || onListInMarketplace);
 
   return (
     <Card glowOnHover className="p-6 h-full flex flex-col gap-5">
@@ -203,6 +213,31 @@ export const SolutionCard: React.FC<SolutionCardProps> = ({ data, onEdit }) => {
               {tag}
             </span>
           ))}
+        </div>
+      )}
+
+      {hasFooterActions && (
+        <div className="mt-auto flex flex-wrap gap-2 pt-2">
+          {onCreateTemplate && (
+            <Button
+              size="xs"
+              variant="outline"
+              onClick={() => onCreateTemplate(data)}
+              className="text-[var(--fg-muted)] hover:text-[var(--fg)]"
+            >
+              Create Template
+            </Button>
+          )}
+          {onListInMarketplace && (
+            <Button
+              size="xs"
+              variant="outline"
+              onClick={() => onListInMarketplace(data)}
+              className="text-[var(--fg-muted)] hover:text-[var(--fg)]"
+            >
+              List in Marketplace
+            </Button>
+          )}
         </div>
       )}
     </Card>

--- a/src/components/Solutions/SystemFormModal.tsx
+++ b/src/components/Solutions/SystemFormModal.tsx
@@ -1,0 +1,221 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import { X, Wrench } from 'lucide-react';
+import { Button } from '../Shared/Button';
+import type { Project, System } from '../../types';
+
+export interface SystemFormValues {
+  systemId?: string;
+  projectId: string;
+  name: string;
+  description: string;
+  type: System['type'];
+  status: System['status'];
+  businessImpact: string;
+}
+
+interface SystemFormModalProps {
+  isOpen: boolean;
+  mode: 'create' | 'edit';
+  projects: Project[];
+  initialValues?: SystemFormValues;
+  onClose: () => void;
+  onSubmit: (values: SystemFormValues) => void;
+}
+
+const fieldClassName =
+  'w-full rounded-lg border border-[var(--border)] bg-[var(--surface)] px-3 py-2 text-sm text-[var(--fg)] focus:outline-none focus:ring-2 focus:ring-[var(--accent-purple)] focus:border-transparent transition';
+
+const labelClassName = 'text-xs font-medium uppercase tracking-wide text-[var(--fg-muted)]';
+
+const SystemFormModal: React.FC<SystemFormModalProps> = ({
+  isOpen,
+  mode,
+  projects,
+  initialValues,
+  onClose,
+  onSubmit,
+}) => {
+  const defaultProjectId = useMemo(() => initialValues?.projectId || projects[0]?.id || '', [initialValues?.projectId, projects]);
+
+  const [formValues, setFormValues] = useState<SystemFormValues>({
+    systemId: initialValues?.systemId,
+    projectId: defaultProjectId,
+    name: initialValues?.name || '',
+    description: initialValues?.description || '',
+    type: initialValues?.type || 'automation',
+    status: initialValues?.status || 'development',
+    businessImpact: initialValues?.businessImpact || '',
+  });
+
+  useEffect(() => {
+    if (!isOpen) {
+      return;
+    }
+
+    setFormValues({
+      systemId: initialValues?.systemId,
+      projectId: initialValues?.projectId || projects[0]?.id || '',
+      name: initialValues?.name || '',
+      description: initialValues?.description || '',
+      type: initialValues?.type || 'automation',
+      status: initialValues?.status || 'development',
+      businessImpact: initialValues?.businessImpact || '',
+    });
+  }, [initialValues, isOpen, projects]);
+
+  if (!isOpen) {
+    return null;
+  }
+
+  const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!formValues.projectId) {
+      return;
+    }
+
+    onSubmit({ ...formValues, businessImpact: formValues.businessImpact.trim() });
+  };
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 px-4 py-6"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="system-form-title"
+      onClick={onClose}
+    >
+      <div
+        className="w-full max-w-2xl overflow-hidden rounded-2xl border border-[var(--border)] bg-[var(--card)] shadow-2xl"
+        onClick={(event) => event.stopPropagation()}
+      >
+        <div className="flex items-center justify-between gap-4 border-b border-[var(--border)] bg-[var(--surface)]/70 px-6 py-4">
+          <div className="flex items-center gap-2">
+            <Wrench className="h-5 w-5 text-[var(--fg-muted)]" />
+            <div>
+              <h2 id="system-form-title" className="text-lg font-semibold text-[var(--fg)]">
+                {mode === 'create' ? 'Create system' : 'Edit system'}
+              </h2>
+              <p className="text-sm text-[var(--fg-muted)]">
+                Define how this system operates within its project workspace.
+              </p>
+            </div>
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            className="rounded-full p-2 text-[var(--fg-muted)] transition hover:bg-[var(--surface)] hover:text-[var(--fg)]"
+            aria-label="Close system form"
+          >
+            <X className="h-4 w-4" />
+          </button>
+        </div>
+
+        <form className="space-y-5 p-6" onSubmit={handleSubmit}>
+          <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+            <label className="space-y-1">
+              <span className={labelClassName}>Project</span>
+              <select
+                className={fieldClassName}
+                value={formValues.projectId}
+                onChange={(event) =>
+                  setFormValues((prev) => ({ ...prev, projectId: event.target.value }))
+                }
+                disabled={mode === 'edit'}
+                required
+              >
+                {projects.map((project) => (
+                  <option key={project.id} value={project.id}>
+                    {project.name}
+                  </option>
+                ))}
+              </select>
+            </label>
+
+            <label className="space-y-1">
+              <span className={labelClassName}>Status</span>
+              <select
+                className={fieldClassName}
+                value={formValues.status}
+                onChange={(event) =>
+                  setFormValues((prev) => ({ ...prev, status: event.target.value as System['status'] }))
+                }
+              >
+                {['design', 'development', 'testing', 'active', 'inactive'].map((status) => (
+                  <option key={status} value={status}>
+                    {status.charAt(0).toUpperCase() + status.slice(1)}
+                  </option>
+                ))}
+              </select>
+            </label>
+
+            <label className="space-y-1">
+              <span className={labelClassName}>System name</span>
+              <input
+                className={fieldClassName}
+                value={formValues.name}
+                onChange={(event) =>
+                  setFormValues((prev) => ({ ...prev, name: event.target.value }))
+                }
+                placeholder="Invoice processing engine"
+                required
+              />
+            </label>
+
+            <label className="space-y-1">
+              <span className={labelClassName}>System type</span>
+              <select
+                className={fieldClassName}
+                value={formValues.type}
+                onChange={(event) =>
+                  setFormValues((prev) => ({ ...prev, type: event.target.value as System['type'] }))
+                }
+              >
+                {['automation', 'workflow', 'integration', 'ai-model'].map((type) => (
+                  <option key={type} value={type}>
+                    {type.replace('-', ' ')}
+                  </option>
+                ))}
+              </select>
+            </label>
+          </div>
+
+          <label className="space-y-1">
+            <span className={labelClassName}>Description</span>
+            <textarea
+              className={`${fieldClassName} min-h-[120px]`}
+              value={formValues.description}
+              onChange={(event) =>
+                setFormValues((prev) => ({ ...prev, description: event.target.value }))
+              }
+              placeholder="Describe the primary workflow and value this system delivers."
+              required
+            />
+          </label>
+
+          <label className="space-y-1">
+            <span className={labelClassName}>Business impact</span>
+            <textarea
+              className={`${fieldClassName} min-h-[100px]`}
+              value={formValues.businessImpact}
+              onChange={(event) =>
+                setFormValues((prev) => ({ ...prev, businessImpact: event.target.value }))
+              }
+              placeholder="Share the measurable impact this system creates for the team or client."
+            />
+          </label>
+
+          <div className="flex items-center justify-end gap-3">
+            <Button type="button" variant="ghost" size="sm" onClick={onClose}>
+              Cancel
+            </Button>
+            <Button type="submit" variant="primary" size="sm" glowOnHover>
+              {mode === 'create' ? 'Create system' : 'Save changes'}
+            </Button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+};
+
+export default SystemFormModal;

--- a/src/components/Solutions/TemplateFormModal.tsx
+++ b/src/components/Solutions/TemplateFormModal.tsx
@@ -1,0 +1,196 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import { FileText, X } from 'lucide-react';
+import { Button } from '../Shared/Button';
+import type { Client } from '../../types';
+
+export interface TemplateFormValues {
+  templateId?: string;
+  clientId: string;
+  name: string;
+  category: string;
+  usage: number;
+  description?: string;
+}
+
+interface TemplateFormModalProps {
+  isOpen: boolean;
+  mode: 'create' | 'edit';
+  clients: Client[];
+  initialValues?: TemplateFormValues;
+  onClose: () => void;
+  onSubmit: (values: TemplateFormValues) => void;
+}
+
+const inputClassName =
+  'w-full rounded-lg border border-[var(--border)] bg-[var(--surface)] px-3 py-2 text-sm text-[var(--fg)] focus:outline-none focus:ring-2 focus:ring-[var(--accent-purple)] focus:border-transparent transition';
+
+const labelClassName = 'text-xs font-medium uppercase tracking-wide text-[var(--fg-muted)]';
+
+const TemplateFormModal: React.FC<TemplateFormModalProps> = ({
+  isOpen,
+  mode,
+  clients,
+  initialValues,
+  onClose,
+  onSubmit,
+}) => {
+  const defaultClientId = useMemo(() => initialValues?.clientId || clients[0]?.id || '', [initialValues?.clientId, clients]);
+
+  const [formValues, setFormValues] = useState<TemplateFormValues>({
+    templateId: initialValues?.templateId,
+    clientId: defaultClientId,
+    name: initialValues?.name || '',
+    category: initialValues?.category || '',
+    usage: initialValues?.usage ?? 0,
+    description: initialValues?.description || '',
+  });
+
+  useEffect(() => {
+    if (!isOpen) {
+      return;
+    }
+
+    setFormValues({
+      templateId: initialValues?.templateId,
+      clientId: initialValues?.clientId || clients[0]?.id || '',
+      name: initialValues?.name || '',
+      category: initialValues?.category || '',
+      usage: initialValues?.usage ?? 0,
+      description: initialValues?.description || '',
+    });
+  }, [clients, initialValues, isOpen]);
+
+  if (!isOpen) {
+    return null;
+  }
+
+  const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!formValues.clientId) {
+      return;
+    }
+
+    onSubmit({ ...formValues, description: formValues.description?.trim() || undefined });
+  };
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 px-4 py-6"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="template-form-title"
+      onClick={onClose}
+    >
+      <div
+        className="w-full max-w-2xl overflow-hidden rounded-2xl border border-[var(--border)] bg-[var(--card)] shadow-2xl"
+        onClick={(event) => event.stopPropagation()}
+      >
+        <div className="flex items-center justify-between gap-4 border-b border-[var(--border)] bg-[var(--surface)]/70 px-6 py-4">
+          <div className="flex items-center gap-2">
+            <FileText className="h-5 w-5 text-[var(--fg-muted)]" />
+            <div>
+              <h2 id="template-form-title" className="text-lg font-semibold text-[var(--fg)]">
+                {mode === 'create' ? 'Create template' : 'Edit template'}
+              </h2>
+              <p className="text-sm text-[var(--fg-muted)]">
+                Package your best workflows and automations for reuse.
+              </p>
+            </div>
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            className="rounded-full p-2 text-[var(--fg-muted)] transition hover:bg-[var(--surface)] hover:text-[var(--fg)]"
+            aria-label="Close template form"
+          >
+            <X className="h-4 w-4" />
+          </button>
+        </div>
+
+        <form className="space-y-5 p-6" onSubmit={handleSubmit}>
+          <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+            <label className="space-y-1">
+              <span className={labelClassName}>Client / owner</span>
+              <select
+                className={inputClassName}
+                value={formValues.clientId}
+                onChange={(event) =>
+                  setFormValues((prev) => ({ ...prev, clientId: event.target.value }))
+                }
+                required
+              >
+                {clients.map((client) => (
+                  <option key={client.id} value={client.id}>
+                    {client.companyName}
+                  </option>
+                ))}
+              </select>
+            </label>
+
+            <label className="space-y-1">
+              <span className={labelClassName}>Category</span>
+              <input
+                className={inputClassName}
+                value={formValues.category}
+                onChange={(event) =>
+                  setFormValues((prev) => ({ ...prev, category: event.target.value }))
+                }
+                placeholder="Automation"
+                required
+              />
+            </label>
+
+            <label className="space-y-1">
+              <span className={labelClassName}>Template name</span>
+              <input
+                className={inputClassName}
+                value={formValues.name}
+                onChange={(event) =>
+                  setFormValues((prev) => ({ ...prev, name: event.target.value }))
+                }
+                placeholder="Onboarding workflow template"
+                required
+              />
+            </label>
+
+            <label className="space-y-1">
+              <span className={labelClassName}>Usage</span>
+              <input
+                type="number"
+                min="0"
+                className={inputClassName}
+                value={formValues.usage}
+                onChange={(event) =>
+                  setFormValues((prev) => ({ ...prev, usage: Number(event.target.value) || 0 }))
+                }
+              />
+            </label>
+          </div>
+
+          <label className="space-y-1">
+            <span className={labelClassName}>Description</span>
+            <textarea
+              className={`${inputClassName} min-h-[120px]`}
+              value={formValues.description || ''}
+              onChange={(event) =>
+                setFormValues((prev) => ({ ...prev, description: event.target.value }))
+              }
+              placeholder="Explain the best use case for this template."
+            />
+          </label>
+
+          <div className="flex items-center justify-end gap-3">
+            <Button type="button" variant="ghost" size="sm" onClick={onClose}>
+              Cancel
+            </Button>
+            <Button type="submit" variant="primary" size="sm" glowOnHover>
+              {mode === 'create' ? 'Create template' : 'Save changes'}
+            </Button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+};
+
+export default TemplateFormModal;

--- a/src/lib/navigation.ts
+++ b/src/lib/navigation.ts
@@ -5,7 +5,7 @@ import type { NavigationItem, ViewId } from '../types/navigation';
 export const NAVIGATION_ITEMS: NavigationItem[] = [
   { id: 'dashboard', label: 'Dashboard', icon: LayoutDashboard },
   { id: 'workspaces', label: 'Workspaces', icon: PanelsTopLeft },
-  { id: 'solutions', label: 'Solutions Hub', icon: Share2 },
+  { id: 'solutions', label: 'Systems Hub', icon: Share2 },
 ];
 
 export const DEFAULT_VIEW_ID: ViewId = NAVIGATION_ITEMS[0]?.id ?? 'dashboard';

--- a/src/views/Solutions.tsx
+++ b/src/views/Solutions.tsx
@@ -1,5 +1,5 @@
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
-import { BarChart3, Filter, PlusCircle, Search } from 'lucide-react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { BarChart3, PlusCircle, Search } from 'lucide-react';
 import { useTools } from '../hooks/useTools';
 import { useProjects } from '../hooks/useProjects';
 import { useClients } from '../hooks/useClients';
@@ -10,22 +10,71 @@ import { Tool } from '../types/tools';
 import { Button } from '../components/Shared/Button';
 import { Card } from '../components/Shared/Card';
 import RoiManagerModal from '../components/Solutions/RoiManagerModal';
+import SystemFormModal, { SystemFormValues } from '../components/Solutions/SystemFormModal';
+import TemplateFormModal, { TemplateFormValues } from '../components/Solutions/TemplateFormModal';
+import MarketplaceFormModal, { MarketplaceFormValues } from '../components/Solutions/MarketplaceFormModal';
 import type { ResourceOption, RoiMetricRecord } from '../types/roi';
+import type { Client, ClientLibraryItem, ClientTemplate, Project, System } from '../types';
 
-const solutionTypes = ['tool', 'system', 'template', 'marketplace'] as const;
+const hubViews = ['active', 'library', 'marketplace'] as const;
 
-type SolutionType = (typeof solutionTypes)[number];
+type HubView = (typeof hubViews)[number];
+
+type ActiveStatusFilter = 'all' | 'active' | 'testing' | 'development';
 
 type ToolFormState = {
   mode: 'create' | 'edit';
   tool?: Tool;
 };
 
-const typeLabels: Record<SolutionType, string> = {
-  tool: 'Tools',
-  system: 'Systems',
-  template: 'Templates',
+type SystemFormState = {
+  mode: 'create' | 'edit';
+  initialValues?: SystemFormValues;
+};
+
+type TemplateModalState = {
+  mode: 'create' | 'edit';
+  initialValues?: TemplateFormValues;
+};
+
+type MarketplaceModalState = {
+  mode: 'create' | 'edit';
+  initialValues?: MarketplaceFormValues;
+};
+
+const viewLabels: Record<HubView, string> = {
+  active: 'Active',
+  library: 'Library',
   marketplace: 'Marketplace',
+};
+
+type ActiveItemEntry = {
+  card: SolutionCardData;
+  meta:
+    | { kind: 'tool'; tool: Tool }
+    | { kind: 'system'; system: System; project: Project; client: Client | null };
+};
+
+type LibraryItemEntry = {
+  card: SolutionCardData;
+  meta: {
+    kind: 'template';
+    template: ClientTemplate;
+    client: Client;
+    description: string;
+  };
+};
+
+type MarketplaceItemEntry = {
+  card: SolutionCardData;
+  meta: {
+    kind: 'marketplace';
+    item: ClientLibraryItem;
+    client: Client;
+    description: string;
+    downloads: number;
+    rating: number;
+  };
 };
 
 const formatCurrency = (value: number) => {
@@ -52,16 +101,91 @@ const deterministicNumber = (seed: string, min: number, max: number) => {
 
 const Solutions: React.FC = () => {
   const { tools, isLoading: loadingTools, createTool, updateTool } = useTools();
-  const { projects } = useProjects();
-  const { clients } = useClients();
+  const { projects, updateProject } = useProjects();
+  const { clients, updateClient } = useClients();
   const { teamMembers } = useTeam();
 
   const [searchTerm, setSearchTerm] = useState('');
-  const [activeTypes, setActiveTypes] = useState<SolutionType[]>([...solutionTypes]);
-  const [statusFilter, setStatusFilter] = useState<string>('all');
+  const [activeView, setActiveView] = useState<HubView>('active');
+  const [activeStatusFilter, setActiveStatusFilter] = useState<ActiveStatusFilter>('all');
   const [roiMetrics, setRoiMetrics] = useState<Record<string, RoiMetricRecord>>({});
   const [toolFormState, setToolFormState] = useState<ToolFormState | null>(null);
+  const [systemFormState, setSystemFormState] = useState<SystemFormState | null>(null);
+  const [templateFormState, setTemplateFormState] = useState<TemplateModalState | null>(null);
+  const [marketplaceFormState, setMarketplaceFormState] = useState<MarketplaceModalState | null>(null);
   const [isRoiManagerOpen, setIsRoiManagerOpen] = useState(false);
+  const [templateDescriptions, setTemplateDescriptions] = useState<Record<string, string>>({});
+  const [marketplaceDescriptions, setMarketplaceDescriptions] = useState<Record<string, string>>({});
+  const [marketplaceMetrics, setMarketplaceMetrics] = useState<Record<string, { downloads: number; rating: number }>>({});
+  const [showCreateMenu, setShowCreateMenu] = useState(false);
+  const createMenuRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    if (!showCreateMenu) {
+      return;
+    }
+
+    const handleClick = (event: MouseEvent) => {
+      if (createMenuRef.current && !createMenuRef.current.contains(event.target as Node)) {
+        setShowCreateMenu(false);
+      }
+    };
+
+    document.addEventListener('mousedown', handleClick);
+    return () => document.removeEventListener('mousedown', handleClick);
+  }, [showCreateMenu]);
+
+  useEffect(() => {
+    setTemplateDescriptions((prev) => {
+      const next = { ...prev };
+      clients.forEach((client) => {
+        client.templates.forEach((template) => {
+          const key = `${client.id}-${template.id}`;
+          if (!next[key]) {
+            next[key] = `${template.category} playbook maintained by ${client.companyName}.`;
+          }
+        });
+      });
+      return next;
+    });
+  }, [clients]);
+
+  useEffect(() => {
+    setMarketplaceDescriptions((prev) => {
+      const next = { ...prev };
+      clients.forEach((client) => {
+        client.library.forEach((item) => {
+          const key = `${client.id}-${item.id}`;
+          if (!next[key]) {
+            next[key] = `${item.type} contribution from ${client.companyName}.`;
+          }
+        });
+      });
+      return next;
+    });
+
+    setMarketplaceMetrics((prev) => {
+      const next = { ...prev };
+      clients.forEach((client) => {
+        client.library.forEach((item) => {
+          const key = `${client.id}-${item.id}`;
+          if (!next[key]) {
+            next[key] = {
+              downloads: deterministicNumber(item.id, 120, 1400),
+              rating: Number((deterministicNumber(`${item.id}-rating`, 40, 50) / 10).toFixed(1)),
+            };
+          }
+        });
+      });
+      return next;
+    });
+  }, [clients]);
+
+  useEffect(() => {
+    if (activeView !== 'active') {
+      setIsRoiManagerOpen(false);
+    }
+  }, [activeView]);
 
   const systems = useMemo(() => {
     return projects.flatMap((project) =>
@@ -73,34 +197,50 @@ const Solutions: React.FC = () => {
     );
   }, [projects, clients]);
 
-  const templates = useMemo(() => (
-    clients.flatMap((client) =>
-      client.templates.map((template) => ({
-        id: `${client.id}-${template.id}`,
-        name: template.name,
-        description: `${template.category} playbook maintained by ${client.companyName}.`,
-        category: template.category,
-        usage: template.usage,
-        owner: client.companyName,
-        lastModified: template.lastModified,
-      }))
-    )
-  ), [clients]);
+  const libraryItems = useMemo(
+    () =>
+      clients.flatMap((client) =>
+        client.templates.map((template) => {
+          const key = `${client.id}-${template.id}`;
+          return {
+            id: key,
+            templateId: template.id,
+            clientId: client.id,
+            clientName: client.companyName,
+            name: template.name,
+            description: templateDescriptions[key] || `${template.category} playbook maintained by ${client.companyName}.`,
+            category: template.category,
+            usage: template.usage,
+            lastModified: template.lastModified,
+          };
+        })
+      ),
+    [clients, templateDescriptions]
+  );
 
-  const marketplaceItems = useMemo(() => (
-    clients.flatMap((client) =>
-      client.library.map((item) => ({
-        id: `${client.id}-${item.id}`,
-        name: item.name,
-        description: `${item.type} contribution from ${client.companyName}.`,
-        category: item.category,
-        owner: client.companyName,
-        downloads: deterministicNumber(item.id, 120, 1400),
-        rating: (deterministicNumber(`${item.id}-rating`, 40, 50) / 10).toFixed(1),
-        createdAt: item.createdAt,
-      }))
-    )
-  ), [clients]);
+  const marketplaceItems = useMemo(
+    () =>
+      clients.flatMap((client) =>
+        client.library.map((item) => {
+          const key = `${client.id}-${item.id}`;
+          const metrics = marketplaceMetrics[key] || { downloads: 0, rating: 0 };
+          return {
+            id: key,
+            itemId: item.id,
+            clientId: client.id,
+            clientName: client.companyName,
+            name: item.name,
+            type: item.type,
+            description: marketplaceDescriptions[key] || `${item.type} contribution from ${client.companyName}.`,
+            category: item.category,
+            downloads: metrics.downloads,
+            rating: metrics.rating,
+            createdAt: item.createdAt,
+          };
+        })
+      ),
+    [clients, marketplaceDescriptions, marketplaceMetrics]
+  );
 
   useEffect(() => {
     setRoiMetrics((prev) => {
@@ -166,133 +306,226 @@ const Solutions: React.FC = () => {
     [roiMetrics]
   );
 
-  const solutionItems: SolutionCardData[] = useMemo(() => {
-    const items: SolutionCardData[] = [];
+  const activeItems = useMemo<ActiveItemEntry[]>(() => {
+    const entries: ActiveItemEntry[] = [];
 
     tools.forEach((tool) => {
-      items.push({
-        id: tool.id,
-        type: 'tool',
-        title: tool.name,
-        description: tool.description,
-        status: tool.status,
-        owner: tool.clientName ? `Client • ${tool.clientName}` : undefined,
-        meta: `Project • ${tool.projectName}`,
-        tags: [tool.category.toLowerCase(), tool.projectName, tool.clientName].filter(Boolean) as string[],
-        metrics: [
-          { label: 'Usage', value: `${tool.stats.usage}%`, tone: 'positive' },
-          { label: 'Efficiency', value: `${tool.stats.efficiency}%`, tone: 'positive' },
-        ],
-        roi: formatRoi(`tool-${tool.id}`),
+      entries.push({
+        card: {
+          id: tool.id,
+          type: 'tool',
+          title: tool.name,
+          description: tool.description,
+          status: tool.status,
+          owner: tool.clientName ? `Client • ${tool.clientName}` : undefined,
+          meta: tool.projectName ? `Project • ${tool.projectName}` : undefined,
+          tags: [tool.category.toLowerCase(), tool.projectName, tool.clientName].filter(Boolean) as string[],
+          metrics: [
+            { label: 'Usage', value: `${tool.stats.usage}%`, tone: 'positive' },
+            { label: 'Efficiency', value: `${tool.stats.efficiency}%`, tone: 'positive' },
+          ],
+          roi: formatRoi(`tool-${tool.id}`),
+        },
+        meta: { kind: 'tool', tool },
       });
     });
 
     systems.forEach(({ system, project, client }) => {
-      items.push({
-        id: system.id,
-        type: 'system',
-        title: system.name,
-        description: system.description,
-        status: system.status,
-        owner: client ? `Client • ${client.companyName}` : 'Internal',
-        meta: `Project • ${project.name}`,
-        tags: [system.type, system.status, project.name],
-        metrics: [
-          { label: 'Components', value: String(system.components.length) },
-          { label: 'Connections', value: String(system.connections.length) },
-        ],
-        roi: formatRoi(`system-${system.id}`),
-        access: {
-          mode: 'read-only',
-          label: 'Managed in Projects workspace',
-          description: `Update ${system.name} within the ${project.name} project.`,
+      entries.push({
+        card: {
+          id: system.id,
+          type: 'system',
+          title: system.name,
+          description: system.description,
+          status: system.status,
+          owner: client ? `Client • ${client.companyName}` : 'Internal',
+          meta: `Project • ${project.name}`,
+          tags: [system.type, system.status, project.name],
+          metrics: [
+            { label: 'Components', value: String(system.components.length) },
+            { label: 'Connections', value: String(system.connections.length) },
+          ],
+          roi: formatRoi(`system-${system.id}`),
         },
+        meta: { kind: 'system', system, project, client },
       });
     });
 
-    templates.forEach((template) => {
-      items.push({
-        id: template.id,
-        type: 'template',
-        title: template.name,
-        description: template.description,
-        owner: template.owner,
-        meta: `Last modified • ${new Date(template.lastModified).toLocaleDateString()}`,
-        tags: [template.category.toLowerCase()],
-        metrics: [
-          { label: 'Usage', value: `${template.usage} launches`, tone: 'positive' },
-        ],
-        access: {
-          mode: 'read-only',
-          label: `${template.owner} managed template`,
-          description: 'Templates sync automatically from the client workspace.',
-        },
-      });
-    });
+    return entries;
+  }, [tools, systems, formatRoi]);
 
-    marketplaceItems.forEach((item) => {
-      items.push({
-        id: item.id,
-        type: 'marketplace',
-        title: item.name,
-        description: item.description,
-        owner: item.owner,
-        meta: `Published • ${new Date(item.createdAt).toLocaleDateString()}`,
-        tags: [item.category.toLowerCase()],
-        metrics: [
-          { label: 'Downloads', value: formatNumber(item.downloads), tone: 'positive' },
-          { label: 'Rating', value: `${item.rating}/5`, tone: 'positive' },
-        ],
-        access: {
-          mode: 'read-only',
-          label: 'Curated marketplace asset',
-          description: `Request updates through ${item.owner}.`,
-        },
-      });
-    });
+  const libraryEntries = useMemo<LibraryItemEntry[]>(
+    () =>
+      libraryItems
+        .map((item) => {
+          const client = clients.find((candidate) => candidate.id === item.clientId);
+          const template = client?.templates.find((candidate) => candidate.id === item.templateId);
 
-    return items;
-  }, [tools, systems, templates, marketplaceItems, formatRoi]);
+          if (!client || !template) {
+            return null;
+          }
 
-  const availableStatuses = useMemo(() => {
-    const statuses = new Set<string>();
-    solutionItems.forEach((item) => {
-      if (item.status) statuses.add(item.status);
-    });
-    return Array.from(statuses);
-  }, [solutionItems]);
+          return {
+            card: {
+              id: item.id,
+              type: 'template',
+              title: item.name,
+              description: item.description,
+              owner: `Client • ${client.companyName}`,
+              meta: `Last modified • ${new Date(item.lastModified).toLocaleDateString()}`,
+              tags: [item.category.toLowerCase()],
+              metrics: [
+                { label: 'Usage', value: `${item.usage} launches`, tone: 'positive' },
+              ],
+            },
+            meta: {
+              kind: 'template',
+              template,
+              client,
+              description: item.description,
+            },
+          } satisfies LibraryItemEntry;
+        })
+        .filter((entry): entry is LibraryItemEntry => Boolean(entry)),
+    [clients, libraryItems]
+  );
 
-  const filteredSolutions = useMemo(() => {
+  const marketplaceEntries = useMemo<MarketplaceItemEntry[]>(
+    () =>
+      marketplaceItems
+        .map((item) => {
+          const client = clients.find((candidate) => candidate.id === item.clientId);
+          const libraryItem = client?.library.find((candidate) => candidate.id === item.itemId);
+
+          if (!client || !libraryItem) {
+            return null;
+          }
+
+          return {
+            card: {
+              id: item.id,
+              type: 'marketplace',
+              title: item.name,
+              description: item.description,
+              owner: `Publisher • ${client.companyName}`,
+              meta: `Published • ${new Date(item.createdAt).toLocaleDateString()}`,
+              tags: [item.category.toLowerCase()],
+              metrics: [
+                { label: 'Downloads', value: formatNumber(item.downloads), tone: 'positive' },
+                { label: 'Rating', value: `${item.rating.toFixed(1)}/5`, tone: 'positive' },
+              ],
+            },
+            meta: {
+              kind: 'marketplace',
+              item: libraryItem,
+              client,
+              description: item.description,
+              downloads: item.downloads,
+              rating: item.rating,
+            },
+          } satisfies MarketplaceItemEntry;
+        })
+        .filter((entry): entry is MarketplaceItemEntry => Boolean(entry)),
+    [clients, marketplaceItems]
+  );
+
+  const filteredActiveItems = useMemo(() => {
     const normalizedSearch = searchTerm.trim().toLowerCase();
 
-    return solutionItems.filter((item) => {
-      if (!activeTypes.includes(item.type as SolutionType)) return false;
-      if (statusFilter !== 'all' && item.status !== statusFilter) return false;
+    return activeItems.filter(({ card }) => {
+      if (activeStatusFilter !== 'all' && card.status !== activeStatusFilter) {
+        return false;
+      }
 
-      if (!normalizedSearch) return true;
+      if (!normalizedSearch) {
+        return true;
+      }
 
       const searchable = [
-        item.title,
-        item.description,
-        item.owner,
-        item.meta,
-        ...(item.tags || []),
-        ...item.metrics.map((metric) => metric.label),
-        ...item.metrics.map((metric) => metric.value),
+        card.title,
+        card.description,
+        card.owner,
+        card.meta,
+        ...(card.tags || []),
+        ...card.metrics.map((metric) => metric.label),
+        ...card.metrics.map((metric) => metric.value),
       ]
         .filter(Boolean)
         .map((value) => value.toLowerCase());
 
       return searchable.some((value) => value.includes(normalizedSearch));
     });
-  }, [solutionItems, activeTypes, statusFilter, searchTerm]);
+  }, [activeItems, activeStatusFilter, searchTerm]);
 
-  const summaryStats = useMemo(() => [
-    { label: 'Tools', value: tools.length },
-    { label: 'Systems', value: systems.length },
-    { label: 'Templates', value: templates.length },
-    { label: 'Marketplace Assets', value: marketplaceItems.length },
-  ], [tools.length, systems.length, templates.length, marketplaceItems.length]);
+  const filteredLibraryItems = useMemo(() => {
+    const normalizedSearch = searchTerm.trim().toLowerCase();
+
+    return libraryEntries.filter(({ card }) => {
+      if (!normalizedSearch) {
+        return true;
+      }
+
+      const searchable = [
+        card.title,
+        card.description,
+        card.owner,
+        card.meta,
+        ...(card.tags || []),
+        ...card.metrics.map((metric) => metric.label),
+        ...card.metrics.map((metric) => metric.value),
+      ]
+        .filter(Boolean)
+        .map((value) => value.toLowerCase());
+
+      return searchable.some((value) => value.includes(normalizedSearch));
+    });
+  }, [libraryEntries, searchTerm]);
+
+  const filteredMarketplaceItems = useMemo(() => {
+    const normalizedSearch = searchTerm.trim().toLowerCase();
+
+    return marketplaceEntries.filter(({ card }) => {
+      if (!normalizedSearch) {
+        return true;
+      }
+
+      const searchable = [
+        card.title,
+        card.description,
+        card.owner,
+        card.meta,
+        ...(card.tags || []),
+        ...card.metrics.map((metric) => metric.label),
+        ...card.metrics.map((metric) => metric.value),
+      ]
+        .filter(Boolean)
+        .map((value) => value.toLowerCase());
+
+      return searchable.some((value) => value.includes(normalizedSearch));
+    });
+  }, [marketplaceEntries, searchTerm]);
+
+  const activeSummary = useMemo(
+    () => [
+      { label: 'Active (total)', value: activeItems.length, filter: 'all' as ActiveStatusFilter },
+      {
+        label: 'Deployed',
+        value: activeItems.filter(({ card }) => card.status === 'active').length,
+        filter: 'active' as ActiveStatusFilter,
+      },
+      {
+        label: 'Testing',
+        value: activeItems.filter(({ card }) => card.status === 'testing').length,
+        filter: 'testing' as ActiveStatusFilter,
+      },
+      {
+        label: 'Development',
+        value: activeItems.filter(({ card }) => card.status === 'development').length,
+        filter: 'development' as ActiveStatusFilter,
+      },
+    ],
+    [activeItems]
+  );
 
   const handleManualRoiUpdate = useCallback(
     (key: string, metrics: RoiMetricRecord) => {
@@ -380,25 +613,251 @@ const Solutions: React.FC = () => {
 
     setToolFormState(null);
   };
+  const handleSystemSubmit = (values: SystemFormValues) => {
+    const { systemId, projectId, name, description, status, type, businessImpact } = values;
+    const project = projects.find((candidate) => candidate.id === projectId);
+    if (!project) {
+      setSystemFormState(null);
+      return;
+    }
 
-  const toggleType = (type: SolutionType) => {
-    setActiveTypes((prev) => (prev.includes(type) ? prev.filter((item) => item !== type) : [...prev, type]));
+    if (systemFormState?.mode === 'create') {
+      const newSystem: System = {
+        id: systemId || `system-${Date.now()}`,
+        name,
+        description,
+        status,
+        type,
+        businessImpact,
+        components: [],
+        connections: [],
+        projectId,
+        createdAt: new Date().toISOString(),
+      };
+      updateProject(projectId, { systems: [...project.systems, newSystem] });
+    } else if (systemFormState?.mode === 'edit' && systemId) {
+      const updatedSystems = project.systems.map((system) =>
+        system.id === systemId
+          ? {
+              ...system,
+              name,
+              description,
+              status,
+              type,
+              businessImpact,
+            }
+          : system
+      );
+      updateProject(projectId, { systems: updatedSystems });
+    }
+
+    setSystemFormState(null);
   };
+
+  const handleTemplateSubmit = (values: TemplateFormValues) => {
+    const { templateId, clientId, name, category, usage, description } = values;
+    const client = clients.find((candidate) => candidate.id === clientId);
+
+    if (!client) {
+      setTemplateFormState(null);
+      return;
+    }
+
+    const descriptionValue = description || `${category} playbook maintained by ${client.companyName}.`;
+
+    if (templateFormState?.mode === 'create') {
+      const newTemplateId = templateId || `template-${Date.now()}`;
+      const newTemplate: ClientTemplate = {
+        id: newTemplateId,
+        name,
+        category,
+        usage,
+        lastModified: new Date().toISOString(),
+      };
+      updateClient(clientId, { templates: [...client.templates, newTemplate] });
+      setTemplateDescriptions((prev) => ({
+        ...prev,
+        [`${clientId}-${newTemplateId}`]: descriptionValue,
+      }));
+    } else if (templateFormState?.mode === 'edit' && templateId) {
+      const updatedTemplates = client.templates.map((template) =>
+        template.id === templateId
+          ? { ...template, name, category, usage, lastModified: new Date().toISOString() }
+          : template
+      );
+      updateClient(clientId, { templates: updatedTemplates });
+      setTemplateDescriptions((prev) => ({
+        ...prev,
+        [`${clientId}-${templateId}`]: descriptionValue,
+      }));
+    }
+
+    setTemplateFormState(null);
+  };
+
+  const handleMarketplaceSubmit = (values: MarketplaceFormValues) => {
+    const { itemId, clientId, name, type, category, description, downloads = 0, rating = 0 } = values;
+    const client = clients.find((candidate) => candidate.id === clientId);
+
+    if (!client) {
+      setMarketplaceFormState(null);
+      return;
+    }
+
+    const descriptionValue = description || `${type} contribution from ${client.companyName}.`;
+
+    if (marketplaceFormState?.mode === 'create') {
+      const newItemId = itemId || `market-${Date.now()}`;
+      const newItem: ClientLibraryItem = {
+        id: newItemId,
+        name,
+        type,
+        category,
+        createdAt: new Date().toISOString(),
+      };
+      updateClient(clientId, { library: [...client.library, newItem] });
+      setMarketplaceDescriptions((prev) => ({
+        ...prev,
+        [`${clientId}-${newItemId}`]: descriptionValue,
+      }));
+      setMarketplaceMetrics((prev) => ({
+        ...prev,
+        [`${clientId}-${newItemId}`]: { downloads, rating },
+      }));
+    } else if (marketplaceFormState?.mode === 'edit' && itemId) {
+      const updatedLibrary = client.library.map((item) =>
+        item.id === itemId ? { ...item, name, type, category } : item
+      );
+      updateClient(clientId, { library: updatedLibrary });
+      setMarketplaceDescriptions((prev) => ({
+        ...prev,
+        [`${clientId}-${itemId}`]: descriptionValue,
+      }));
+      setMarketplaceMetrics((prev) => ({
+        ...prev,
+        [`${clientId}-${itemId}`]: { downloads, rating },
+      }));
+    }
+
+    setMarketplaceFormState(null);
+  };
+
+  const handleViewSelect = (view: HubView) => {
+    setActiveView(view);
+    setShowCreateMenu(false);
+    if (view !== 'active') {
+      setActiveStatusFilter('all');
+    }
+  };
+
+  const handleCreateTool = () => {
+    setShowCreateMenu(false);
+    setToolFormState({ mode: 'create' });
+  };
+
+  const handleCreateSystem = () => {
+    setShowCreateMenu(false);
+    setSystemFormState({ mode: 'create' });
+  };
+
+  const handleCreateClick = () => {
+    if (activeView === 'active') {
+      setShowCreateMenu((prev) => !prev);
+      return;
+    }
+
+    if (activeView === 'library') {
+      setTemplateFormState({ mode: 'create' });
+    } else {
+      setMarketplaceFormState({ mode: 'create' });
+    }
+  };
+
+  const handleCreateTemplateFromActive = (entry: ActiveItemEntry) => {
+    if (entry.meta.kind === 'tool') {
+      const tool = entry.meta.tool;
+      const description = tool.businessImpact
+        ? tool.businessImpact
+        : `Template generated from ${tool.name}.`;
+      if (!tool.clientId && !clients[0]) {
+        return;
+      }
+      setTemplateFormState({
+        mode: 'create',
+        initialValues: {
+          clientId: tool.clientId || clients[0]?.id || '',
+          name: `${tool.name} Template`,
+          category: tool.category,
+          usage: 0,
+          description,
+        },
+      });
+    } else {
+      const { system, client } = entry.meta;
+      const description = system.businessImpact
+        ? system.businessImpact
+        : `System blueprint derived from ${system.name}.`;
+      const defaultClientId = client?.id || clients[0]?.id || '';
+      if (!defaultClientId) {
+        return;
+      }
+      setTemplateFormState({
+        mode: 'create',
+        initialValues: {
+          clientId: defaultClientId,
+          name: `${system.name} Template`,
+          category: system.type,
+          usage: 0,
+          description,
+        },
+      });
+    }
+  };
+
+  const handleListTemplateInMarketplace = (entry: LibraryItemEntry) => {
+    if (!clients.length) {
+      return;
+    }
+    setMarketplaceFormState({
+      mode: 'create',
+      initialValues: {
+        clientId: entry.meta.client.id,
+        name: entry.meta.template.name,
+        type: 'template',
+        category: entry.meta.template.category,
+        description: `Marketplace listing for ${entry.meta.template.name}.`,
+      },
+    });
+  };
+
+  const isActiveView = activeView === 'active';
+  const isLibraryView = activeView === 'library';
+  const hasResults = isActiveView
+    ? filteredActiveItems.length > 0
+    : isLibraryView
+      ? filteredLibraryItems.length > 0
+      : filteredMarketplaceItems.length > 0;
+
+  const emptyStateMessage = isActiveView
+    ? 'No systems or tools found'
+    : isLibraryView
+      ? 'No templates in your library yet'
+      : 'No marketplace listings yet';
 
   return (
     <div className="space-y-6">
       <div className="space-y-4">
         <div className="flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
           <div className="space-y-3">
-            <h1 className="text-2xl font-semibold text-[var(--fg)]">Automation & Intelligence Hub</h1>
+            <h1 className="text-2xl font-semibold text-[var(--fg)]">Systems Hub</h1>
             <p className="text-sm text-[var(--fg-muted)]">
-              Explore every agent, workflow, template, and marketplace asset from a single searchable catalog.
+              Manage live systems, reusable templates, and marketplace listings from a single control center.
             </p>
             <div className="relative max-w-xl">
               <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-[var(--fg-muted)]" />
               <input
                 className="w-full rounded-lg border border-[var(--border)] bg-[var(--surface)] py-2 pl-9 pr-3 text-sm text-[var(--fg)] focus:outline-none focus:ring-2 focus:ring-[var(--accent-purple)]"
-                placeholder="Search by tool, system, template, or owner"
+                placeholder="Search systems, templates, or marketplace listings"
                 value={searchTerm}
                 onChange={(event) => setSearchTerm(event.target.value)}
               />
@@ -407,100 +866,171 @@ const Solutions: React.FC = () => {
 
           <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
             <div className="flex flex-wrap gap-2">
-              {solutionTypes.map((type) => {
-                const isActive = activeTypes.includes(type);
+              {hubViews.map((view) => {
+                const isSelected = activeView === view;
                 return (
                   <Button
-                    key={type}
+                    key={view}
                     variant="outline"
                     size="sm"
-                    onClick={() => toggleType(type)}
-                    className={`min-w-[140px] ${
-                      isActive
+                    onClick={() => handleViewSelect(view)}
+                    className={`min-w-[120px] ${
+                      isSelected
                         ? 'border-[var(--accent-purple)] bg-[var(--surface)] text-[var(--fg)] shadow-sm'
                         : 'border-[var(--border)]/80 text-[var(--fg-muted)] hover:text-[var(--fg)]'
                     }`}
                   >
-                    {typeLabels[type]}
+                    {viewLabels[view]}
                   </Button>
                 );
               })}
             </div>
 
             <div className="flex flex-wrap items-center gap-2">
-              <div className="relative">
-                <Filter className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-[var(--fg-muted)]" />
-                <select
-                  className="appearance-none rounded-lg border border-[var(--border)] bg-[var(--surface)] py-2 pl-9 pr-8 text-sm text-[var(--fg)] focus:outline-none focus:ring-2 focus:ring-[var(--accent-purple)]"
-                  value={statusFilter}
-                  onChange={(event) => setStatusFilter(event.target.value)}
+              {isActiveView && (
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => setIsRoiManagerOpen(true)}
+                  disabled={resourceOptions.length === 0}
+                  className="gap-2 text-[var(--fg-muted)] hover:text-[var(--fg)]"
                 >
-                  <option value="all">All statuses</option>
-                  {availableStatuses.map((status) => (
-                    <option key={status} value={status}>
-                      {status.charAt(0).toUpperCase() + status.slice(1)}
-                    </option>
-                  ))}
-                </select>
+                  <BarChart3 className="h-4 w-4" />
+                  Manage ROI
+                </Button>
+              )}
+
+              <div ref={isActiveView ? createMenuRef : undefined} className="relative">
+                <Button variant="primary" size="sm" glowOnHover onClick={handleCreateClick} className="flex items-center gap-2">
+                  <PlusCircle className="h-4 w-4" />
+                  Create
+                </Button>
+                {isActiveView && showCreateMenu && (
+                  <div className="absolute right-0 z-20 mt-2 w-44 overflow-hidden rounded-lg border border-[var(--border)] bg-[var(--card)] shadow-lg">
+                    <button
+                      type="button"
+                      className="w-full px-4 py-2 text-left text-sm text-[var(--fg)] hover:bg-[var(--surface)]"
+                      onClick={handleCreateTool}
+                    >
+                      New Tool
+                    </button>
+                    <button
+                      type="button"
+                      className="w-full px-4 py-2 text-left text-sm text-[var(--fg)] hover:bg-[var(--surface)]"
+                      onClick={handleCreateSystem}
+                    >
+                      New System
+                    </button>
+                  </div>
+                )}
               </div>
-
-              <Button
-                variant="outline"
-                size="sm"
-                onClick={() => setIsRoiManagerOpen(true)}
-                disabled={resourceOptions.length === 0}
-                className="gap-2 text-[var(--fg-muted)] hover:text-[var(--fg)]"
-              >
-                <BarChart3 className="h-4 w-4" />
-                Manage ROI
-              </Button>
-
-              <Button
-                variant="primary"
-                size="sm"
-                glowOnHover
-                onClick={() => setToolFormState({ mode: 'create' })}
-              >
-                <PlusCircle className="mr-2 h-4 w-4" />
-                Add Tool
-              </Button>
             </div>
           </div>
         </div>
 
-        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
-          {summaryStats.map((stat) => (
-            <Card key={stat.label} glowOnHover className="p-4">
-              <p className="text-xs uppercase tracking-wide text-[var(--fg-muted)]">{stat.label}</p>
-              <p className="mt-1 text-2xl font-semibold text-[var(--fg)]">{stat.value}</p>
-            </Card>
-          ))}
-        </div>
+        {isActiveView && (
+          <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
+            {activeSummary.map((stat) => {
+              const isSelected = activeStatusFilter === stat.filter;
+              return (
+                <Card
+                  key={stat.label}
+                  glowOnHover
+                  activeGlow={isSelected}
+                  onClick={() => setActiveStatusFilter(stat.filter)}
+                  className={`p-4 ${isSelected ? 'border-[var(--accent-purple)] bg-[var(--surface)]' : ''}`}
+                >
+                  <p className="text-xs uppercase tracking-wide text-[var(--fg-muted)]">{stat.label}</p>
+                  <p className="mt-1 text-2xl font-semibold text-[var(--fg)]">{stat.value}</p>
+                </Card>
+              );
+            })}
+          </div>
+        )}
       </div>
 
-      {loadingTools ? (
+      {loadingTools && isActiveView ? (
         <div className="flex h-48 items-center justify-center">
           <div className="h-12 w-12 animate-spin rounded-full border-2 border-[var(--accent-orange)] border-t-transparent"></div>
         </div>
-      ) : filteredSolutions.length === 0 ? (
+      ) : !hasResults ? (
         <div className="rounded-2xl border border-[var(--border)] bg-[var(--surface)]/60 p-12 text-center text-[var(--fg-muted)]">
-          <p className="text-lg font-semibold text-[var(--fg)]">No assets found</p>
+          <p className="text-lg font-semibold text-[var(--fg)]">{emptyStateMessage}</p>
           <p className="mt-2 text-sm">Try refining your filters or search keywords.</p>
         </div>
       ) : (
         <div className="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-3">
-          {filteredSolutions.map((item) => (
-            <SolutionCard
-              key={`${item.type}-${item.id}`}
-              data={item}
-              onEdit={item.type === 'tool' ? () => {
-                const tool = tools.find((candidate) => candidate.id === item.id);
-                if (tool) {
-                  setToolFormState({ mode: 'edit', tool });
+          {isActiveView &&
+            filteredActiveItems.map((entry) => (
+              <SolutionCard
+                key={`active-${entry.card.id}`}
+                data={entry.card}
+                onEdit={() => {
+                  if (entry.meta.kind === 'tool') {
+                    setToolFormState({ mode: 'edit', tool: entry.meta.tool });
+                  } else {
+                    setSystemFormState({
+                      mode: 'edit',
+                      initialValues: {
+                        systemId: entry.meta.system.id,
+                        projectId: entry.meta.project.id,
+                        name: entry.meta.system.name,
+                        description: entry.meta.system.description,
+                        status: entry.meta.system.status,
+                        type: entry.meta.system.type,
+                        businessImpact: entry.meta.system.businessImpact,
+                      },
+                    });
+                  }
+                }}
+                onCreateTemplate={() => handleCreateTemplateFromActive(entry)}
+              />
+            ))}
+
+          {isLibraryView &&
+            filteredLibraryItems.map((entry) => (
+              <SolutionCard
+                key={`library-${entry.card.id}`}
+                data={entry.card}
+                onEdit={() =>
+                  setTemplateFormState({
+                    mode: 'edit',
+                    initialValues: {
+                      templateId: entry.meta.template.id,
+                      clientId: entry.meta.client.id,
+                      name: entry.meta.template.name,
+                      category: entry.meta.template.category,
+                      usage: entry.meta.template.usage,
+                      description: entry.meta.description,
+                    },
+                  })
                 }
-              } : undefined}
-            />
-          ))}
+                onListInMarketplace={() => handleListTemplateInMarketplace(entry)}
+              />
+            ))}
+
+          {!isActiveView && !isLibraryView &&
+            filteredMarketplaceItems.map((entry) => (
+              <SolutionCard
+                key={`market-${entry.card.id}`}
+                data={entry.card}
+                onEdit={() =>
+                  setMarketplaceFormState({
+                    mode: 'edit',
+                    initialValues: {
+                      itemId: entry.meta.item.id,
+                      clientId: entry.meta.client.id,
+                      name: entry.meta.item.name,
+                      type: entry.meta.item.type,
+                      category: entry.meta.item.category,
+                      description: entry.meta.description,
+                      downloads: entry.meta.downloads,
+                      rating: entry.meta.rating,
+                    },
+                  })
+                }
+              />
+            ))}
         </div>
       )}
 
@@ -514,6 +1044,33 @@ const Solutions: React.FC = () => {
         teamMembers={teamMembers}
         onClose={() => setToolFormState(null)}
         onSubmit={handleToolSubmit}
+      />
+
+      <SystemFormModal
+        isOpen={Boolean(systemFormState)}
+        mode={systemFormState?.mode || 'create'}
+        projects={projects}
+        initialValues={systemFormState?.initialValues}
+        onClose={() => setSystemFormState(null)}
+        onSubmit={handleSystemSubmit}
+      />
+
+      <TemplateFormModal
+        isOpen={Boolean(templateFormState)}
+        mode={templateFormState?.mode || 'create'}
+        clients={clients}
+        initialValues={templateFormState?.initialValues}
+        onClose={() => setTemplateFormState(null)}
+        onSubmit={handleTemplateSubmit}
+      />
+
+      <MarketplaceFormModal
+        isOpen={Boolean(marketplaceFormState)}
+        mode={marketplaceFormState?.mode || 'create'}
+        clients={clients}
+        initialValues={marketplaceFormState?.initialValues}
+        onClose={() => setMarketplaceFormState(null)}
+        onSubmit={handleMarketplaceSubmit}
       />
 
       <RoiManagerModal


### PR DESCRIPTION
## Summary
- rename the Solutions Hub navigation entry and card copy to Systems Hub
- add dedicated system, template, and marketplace form modals plus expand SolutionCard to surface new actions
- rebuild the Systems Hub view around Active/Library/Marketplace tabs, status insights, contextual create flows, and marketplace/template interactions

## Testing
- `npm run build`
- `npm run lint` *(fails: pre-existing unused variable warning in Sidebar.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68d16d559e0c832d8d620de657b70a17