### PR TITLE
Refine Systems Hub active view and add detail experience

### DIFF
--- a/src/components/Layout/Sidebar.tsx
+++ b/src/components/Layout/Sidebar.tsx
@@ -4,7 +4,6 @@ import { LogOut } from 'lucide-react';
 import { useAuth } from '../../hooks/useAuth';
 import { NAVIGATION_ITEMS } from '../../lib/navigation';
 import type { ViewId } from '../../types/navigation';
-import { Logo } from '../Shared/Logo';
 
 interface SidebarProps {
   activeView: ViewId;
@@ -20,7 +19,7 @@ const Sidebar: React.FC<SidebarProps> = ({ activeView, availablePages, onViewCha
   const menuItems = NAVIGATION_ITEMS.filter((item) => availablePages.includes(item.id));
 
   return (
-    <div className="w-64 bg-[var(--bg-start)] border-r border-[var(--border)] flex flex-col">
+    <div className="w-64 flex-shrink-0 bg-[var(--bg-start)] border-r border-[var(--border)] flex flex-col sticky top-20 h-[calc(100vh-5rem)]">
       <nav className="flex-1 p-4">
         <ul className="space-y-2">
           {menuItems.map((item) => {

--- a/src/components/Shared/Card.tsx
+++ b/src/components/Shared/Card.tsx
@@ -6,6 +6,7 @@ interface CardProps extends React.AriaAttributes {
   glowOnHover?: boolean;
   activeGlow?: boolean;
   onClick?: () => void;
+  glowStyle?: 'gradient' | 'outline';
 }
 
 export function Card({
@@ -13,6 +14,7 @@ export function Card({
   className = "",
   glowOnHover = false,
   activeGlow = false,
+  glowStyle = 'gradient',
   onClick,
   ...ariaProps
 }: CardProps) {
@@ -55,6 +57,36 @@ export function Card({
     : {};
 
   if (glowOnHover || activeGlow) {
+    if (glowStyle === 'outline') {
+      const outlineGlowClass = activeGlow
+        ? 'opacity-100 ring-2 ring-[var(--accent-purple)] shadow-[0_0_20px_rgba(134,86,255,0.35)]'
+        : glowOnHover
+          ? 'opacity-0 group-hover:opacity-100 group-focus-visible:opacity-100 ring-1 ring-[var(--accent-purple)]/60 shadow-[0_0_14px_rgba(134,86,255,0.2)]'
+          : 'opacity-0';
+
+      return (
+        <div
+          className={`relative group ${interactiveClasses}`}
+          {...interactiveProps}
+          {...ariaProps}
+        >
+          <div
+            className={`pointer-events-none absolute inset-0 rounded-xl transition-opacity duration-300 z-0 ${outlineGlowClass}`}
+            aria-hidden="true"
+          />
+          <div
+            className={`
+          relative z-10 h-full rounded-xl border border-[var(--border)] transition-all duration-300
+          bg-[var(--card)] shadow-sm
+          ${className}
+        `}
+          >
+            {children}
+          </div>
+        </div>
+      );
+    }
+
     return (
       <div
         className={`relative group ${interactiveClasses}`}
@@ -62,7 +94,7 @@ export function Card({
         {...ariaProps}
       >
         <div
-          className={`absolute -inset-0.5 bg-gradient-to-r from-[var(--accent-orange)] via-[var(--accent-pink)] to-[var(--accent-purple)] rounded-xl transition-opacity duration-300 z-0 ${
+          className={`pointer-events-none absolute -inset-0.5 bg-gradient-to-r from-[var(--accent-orange)] via-[var(--accent-pink)] to-[var(--accent-purple)] rounded-xl transition-opacity duration-300 z-0 ${
             activeGlow
               ? 'opacity-75'
               : glowOnHover

--- a/src/components/Solutions/RoiManagerModal.tsx
+++ b/src/components/Solutions/RoiManagerModal.tsx
@@ -11,6 +11,7 @@ interface RoiManagerModalProps {
   metricsMap: Record<string, RoiMetricRecord>;
   onManualUpdate: (key: string, metrics: RoiMetricRecord) => void;
   onBulkImport: (updates: Array<{ key: string; metrics: RoiMetricRecord }>) => void;
+  defaultKey?: string;
 }
 
 interface FeedbackState {
@@ -55,6 +56,7 @@ const RoiManagerModal: React.FC<RoiManagerModalProps> = ({
   metricsMap,
   onManualUpdate,
   onBulkImport,
+  defaultKey,
 }) => {
   const [selectedKey, setSelectedKey] = useState<string>('');
   const [formValues, setFormValues] = useState(createEmptyFormState);
@@ -84,10 +86,22 @@ const RoiManagerModal: React.FC<RoiManagerModalProps> = ({
       return;
     }
 
+    if (defaultKey && optionMap.has(defaultKey) && selectedKey !== defaultKey) {
+      setSelectedKey(defaultKey);
+      return;
+    }
+
     if (!selectedKey || !optionMap.has(selectedKey)) {
       setSelectedKey(resourceOptions[0].key);
     }
-  }, [isOpen, hasResources, optionMap, resourceOptions, selectedKey]);
+  }, [
+    isOpen,
+    hasResources,
+    optionMap,
+    resourceOptions,
+    selectedKey,
+    defaultKey,
+  ]);
 
   useEffect(() => {
     if (!isOpen) return;

--- a/src/components/Solutions/SolutionCard.tsx
+++ b/src/components/Solutions/SolutionCard.tsx
@@ -47,6 +47,8 @@ interface SolutionCardProps {
   onEdit?: (data: SolutionCardData) => void;
   onCreateTemplate?: (data: SolutionCardData) => void;
   onListInMarketplace?: (data: SolutionCardData) => void;
+  onSelect?: (data: SolutionCardData) => void;
+  showTags?: boolean;
 }
 
 const typeConfig: Record<SolutionType, { label: string; icon: React.ComponentType<{ className?: string }>; badgeClass: string }> = {
@@ -97,6 +99,8 @@ export const SolutionCard: React.FC<SolutionCardProps> = ({
   onEdit,
   onCreateTemplate,
   onListInMarketplace,
+  onSelect,
+  showTags = true,
 }) => {
   const type = typeConfig[data.type];
   const StatusIcon = type.icon;
@@ -104,8 +108,33 @@ export const SolutionCard: React.FC<SolutionCardProps> = ({
 
   const hasFooterActions = Boolean(onCreateTemplate || onListInMarketplace);
 
+  const handleEditClick: React.MouseEventHandler<HTMLButtonElement> = (event) => {
+    event.stopPropagation();
+    if (onEdit) {
+      onEdit(data);
+    }
+  };
+
+  const handleCreateTemplateClick: React.MouseEventHandler<HTMLButtonElement> = (event) => {
+    event.stopPropagation();
+    if (onCreateTemplate) {
+      onCreateTemplate(data);
+    }
+  };
+
+  const handleListInMarketplaceClick: React.MouseEventHandler<HTMLButtonElement> = (event) => {
+    event.stopPropagation();
+    if (onListInMarketplace) {
+      onListInMarketplace(data);
+    }
+  };
+
   return (
-    <Card glowOnHover className="p-6 h-full flex flex-col gap-5">
+    <Card
+      glowOnHover
+      className="p-6 h-full flex flex-col gap-5"
+      onClick={onSelect ? () => onSelect(data) : undefined}
+    >
       <div className="flex items-start justify-between gap-3">
         <div className="flex items-start gap-3">
           <div className="w-10 h-10 rounded-lg bg-[var(--surface)] flex items-center justify-center">
@@ -129,7 +158,7 @@ export const SolutionCard: React.FC<SolutionCardProps> = ({
         {onEdit && (
           <button
             type="button"
-            onClick={() => onEdit(data)}
+            onClick={handleEditClick}
             className="p-2 rounded-full text-[var(--fg-muted)] hover:text-[var(--fg)] hover:bg-[var(--surface)] transition"
             aria-label={`Edit ${data.title}`}
           >
@@ -206,7 +235,7 @@ export const SolutionCard: React.FC<SolutionCardProps> = ({
         </div>
       )}
 
-      {data.tags.length > 0 && (
+      {showTags && data.tags.length > 0 && (
         <div className="flex flex-wrap gap-2 text-xs text-[var(--fg-muted)]">
           {data.tags.slice(0, 6).map((tag) => (
             <span key={`${data.id}-${tag}`} className="px-2 py-1 rounded-full bg-[var(--surface)] capitalize">
@@ -222,7 +251,7 @@ export const SolutionCard: React.FC<SolutionCardProps> = ({
             <Button
               size="xs"
               variant="outline"
-              onClick={() => onCreateTemplate(data)}
+              onClick={handleCreateTemplateClick}
               className="text-[var(--fg-muted)] hover:text-[var(--fg)]"
             >
               Create Template
@@ -232,7 +261,7 @@ export const SolutionCard: React.FC<SolutionCardProps> = ({
             <Button
               size="xs"
               variant="outline"
-              onClick={() => onListInMarketplace(data)}
+              onClick={handleListInMarketplaceClick}
               className="text-[var(--fg-muted)] hover:text-[var(--fg)]"
             >
               List in Marketplace


### PR DESCRIPTION
## Summary
- add a Systems Hub detail view with ROI visualizations, business context, and relocated Manage ROI access
- make active cards fully interactive while simplifying their presentation and preselecting ROI manager context
- adjust shared card glow styling, keep the sidebar fixed, and support ROI manager default selection

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d1752908a4832db03cde8bdda93330