### PR TITLE
Rename Systems Hub to Solutions Hub and simplify active cards

### DIFF
--- a/src/components/Solutions/SolutionCard.tsx
+++ b/src/components/Solutions/SolutionCard.tsx
@@ -68,7 +68,7 @@ const typeConfig: Record<SolutionType, { label: string; icon: React.ComponentTyp
     badgeClass: 'bg-emerald-500/10 text-emerald-600 dark:text-emerald-300 border-emerald-500/20',
   },
   marketplace: {
-    label: 'Marketplace',
+    label: 'Marketplace Asset',
     icon: ShoppingBag,
     badgeClass: 'bg-amber-500/10 text-amber-600 dark:text-amber-300 border-amber-500/20',
   },

--- a/src/lib/navigation.ts
+++ b/src/lib/navigation.ts
@@ -5,7 +5,7 @@ import type { NavigationItem, ViewId } from '../types/navigation';
 export const NAVIGATION_ITEMS: NavigationItem[] = [
   { id: 'dashboard', label: 'Dashboard', icon: LayoutDashboard },
   { id: 'workspaces', label: 'Workspaces', icon: PanelsTopLeft },
-  { id: 'solutions', label: 'Systems Hub', icon: Share2 },
+  { id: 'solutions', label: 'Solutions Hub', icon: Share2 },
 ];
 
 export const DEFAULT_VIEW_ID: ViewId = NAVIGATION_ITEMS[0]?.id ?? 'dashboard';

--- a/src/views/Solutions.tsx
+++ b/src/views/Solutions.tsx
@@ -731,13 +731,9 @@ const Solutions: React.FC = () => {
           title: tool.name,
           description: tool.description,
           status: tool.status,
-          owner: tool.clientName ? `Client • ${tool.clientName}` : undefined,
-          meta: tool.projectName ? `Project • ${tool.projectName}` : undefined,
-          tags: [tool.category.toLowerCase(), tool.projectName, tool.clientName].filter(Boolean) as string[],
-          metrics: [
-            { label: 'Usage', value: `${tool.stats.usage}%`, tone: 'positive' },
-            { label: 'Efficiency', value: `${tool.stats.efficiency}%`, tone: 'positive' },
-          ],
+          owner: tool.clientName ? `Client • ${tool.clientName}` : 'Internal',
+          tags: [],
+          metrics: [],
           roi: formatRoi(`tool-${tool.id}`),
         },
         meta: { kind: 'tool', tool },
@@ -753,12 +749,8 @@ const Solutions: React.FC = () => {
           description: system.description,
           status: system.status,
           owner: client ? `Client • ${client.companyName}` : 'Internal',
-          meta: `Project • ${project.name}`,
-          tags: [system.type, system.status, project.name],
-          metrics: [
-            { label: 'Components', value: String(system.components.length) },
-            { label: 'Connections', value: String(system.connections.length) },
-          ],
+          tags: [],
+          metrics: [],
           roi: formatRoi(`system-${system.id}`),
         },
         meta: { kind: 'system', system, project, client },
@@ -932,7 +924,7 @@ const Solutions: React.FC = () => {
 
   const activeSummary = useMemo(
     () => [
-      { label: 'Active (total)', value: activeItems.length, filter: 'all' as ActiveStatusFilter },
+      { label: 'Total', value: activeItems.length, filter: 'all' as ActiveStatusFilter },
       {
         label: 'Deployed',
         value: activeItems.filter(({ card }) => card.status === 'active').length,
@@ -1278,7 +1270,7 @@ const Solutions: React.FC = () => {
       <div className="space-y-4">
         <div className="flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
           <div className="space-y-3">
-            <h1 className="text-2xl font-semibold text-[var(--fg)]">Systems Hub</h1>
+            <h1 className="text-2xl font-semibold text-[var(--fg)]">Solutions Hub</h1>
             <p className="text-sm text-[var(--fg-muted)]">
               Manage live systems, reusable templates, and marketplace listings from a single control center.
             </p>


### PR DESCRIPTION
## Summary
- rename the Systems Hub navigation and header copy to Solutions Hub and retitle the Total summary card
- streamline active tool and system cards to focus on client, description, ROI snapshot, and template creation while updating marketplace badge copy
- ensure Marketplace assets and Library templates remain isolated in their respective views

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d187e9c3cc832db7408ce03197ece7