### PR TITLE
Reorder project status summary display

### DIFF
--- a/src/views/Workspaces.tsx
+++ b/src/views/Workspaces.tsx
@@ -215,10 +215,10 @@ const Workspaces: React.FC = () => {
   const summaryStats = useMemo(() => {
     if (selectedView === 'project') {
       const statusOrder: Project['status'][] = [
-        'planning',
-        'development',
-        'testing',
         'deployed',
+        'testing',
+        'development',
+        'planning',
         'maintenance',
       ];
 


### PR DESCRIPTION
## Summary
- reorder the project summary status list to prioritize deployed, testing, development, planning, and maintenance
- ensure the summary still maps each status to its label and count after the reorder

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d19d9d304c832dac57a348488812e5