### PR TITLE
Hide active summary when viewing details

### DIFF
--- a/src/views/Solutions.tsx
+++ b/src/views/Solutions.tsx
@@ -1399,7 +1399,7 @@ const Solutions: React.FC = () => {
           </div>
         </div>
 
-        {isActiveView && (
+        {isActiveView && !selectedActiveEntry && (
           <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
             {activeSummary.map((stat) => {
               const isSelected = activeStatusFilter === stat.filter;


### PR DESCRIPTION
## Summary
- hide the active summary tiles whenever a detail view is selected to avoid duplicate content alongside the inspector

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d19e41dde0832d9ae00dc861be4587