### PR TITLE
Refactor ROI metrics to capture baseline and post values

### DIFF
--- a/src/types/roi.ts
+++ b/src/types/roi.ts
@@ -1,11 +1,36 @@
+export interface RoiMetricValue {
+  pre: number;
+  post: number;
+}
+
+export const ROI_METRIC_KEYS = [
+  'costSavings',
+  'revenueGenerated',
+  'hoursSaved',
+  'adoptionRate',
+  'efficiencyGain',
+] as const;
+
+export type RoiMetricKey = (typeof ROI_METRIC_KEYS)[number];
+
+export type RoiMetricUnit = 'currency' | 'hours' | 'percentage';
+
 export interface RoiMetricRecord {
-  costSavings: number;
-  hoursSaved: number;
-  revenueGenerated: number;
-  adoptionRate: number;
-  efficiencyGain: number;
+  costSavings: RoiMetricValue;
+  revenueGenerated: RoiMetricValue;
+  hoursSaved: RoiMetricValue;
+  adoptionRate: RoiMetricValue;
+  efficiencyGain: RoiMetricValue;
   lastUpdated: string;
 }
+
+export const ROI_METRIC_CONFIG: Record<RoiMetricKey, { label: string; unit: RoiMetricUnit }> = {
+  costSavings: { label: 'Cost Savings', unit: 'currency' },
+  revenueGenerated: { label: 'Revenue Impact', unit: 'currency' },
+  hoursSaved: { label: 'Hours Saved', unit: 'hours' },
+  adoptionRate: { label: 'Adoption Rate', unit: 'percentage' },
+  efficiencyGain: { label: 'Efficiency Gain', unit: 'percentage' },
+};
 
 export interface ResourceOption {
   key: string;


### PR DESCRIPTION
## Summary
- store ROI metrics as pre/post pairs alongside metric metadata for consistent formatting
- refresh the Solutions view to render delta-based ROI summaries and seed tools/systems with the new structure
- update the ROI manager modal to collect paired pre/post inputs and import/export CSVs with the expanded schema

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d19f1b1e10832d83d508cd7690a7f0