### PR TITLE
Update dashboard categories and enforce ordering

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build": "vite build",
     "lint": "eslint .",
     "test": "npm run test:solutions",
-    "test:solutions": "tsc --project tsconfig.test.json && node --experimental-specifier-resolution=node .test-build/views/__tests__/solutionsFilters.test.js",
+    "test:solutions": "tsc --project tsconfig.test.json && node --experimental-specifier-resolution=node .test-build/views/__tests__/solutionsFilters.test.js && node --experimental-specifier-resolution=node .test-build/views/__tests__/dashboardCategories.test.js",
     "preview": "vite preview"
   },
   "dependencies": {

--- a/src/views/Dashboard.tsx
+++ b/src/views/Dashboard.tsx
@@ -1,5 +1,4 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
-import type { LucideIcon } from 'lucide-react';
 import {
   Handshake,
   FolderOpen,
@@ -19,6 +18,12 @@ import { useTeam } from '../hooks/useTeam';
 import { useTools } from '../hooks/useTools';
 import type { Client, Project, TeamMember } from '../types';
 import type { Tool } from '../types/tools';
+import {
+  CATEGORY_METADATA,
+  CATEGORY_ORDER,
+  type MetricCategory,
+  type MetricCategoryMetadata,
+} from './dashboardCategories';
 
 const ACTIVE_PROJECT_STATUSES = new Set(['planning', 'development', 'testing', 'maintenance']);
 const METRIC_STORAGE_KEY = 'friday-dashboard-metric-selections';
@@ -33,48 +38,6 @@ const TONE_CLASSES = {
 
 type MetricTone = keyof typeof TONE_CLASSES;
 
-type MetricCategoryMetadata = {
-  title: string;
-  description: string;
-  icon: LucideIcon;
-  accent: string;
-};
-
-type CategoryMetadataRecord = {
-  clients: MetricCategoryMetadata;
-  projects: MetricCategoryMetadata;
-  team: MetricCategoryMetadata;
-  automation: MetricCategoryMetadata;
-};
-
-const CATEGORY_METADATA: CategoryMetadataRecord = {
-  clients: {
-    title: 'Client Success',
-    description: 'Pipeline health, relationships, and commercial momentum.',
-    icon: Handshake,
-    accent: 'from-sky-500/10 via-sky-500/5 to-transparent',
-  },
-  projects: {
-    title: 'Delivery Operations',
-    description: 'Monitor how projects move from planning through deployment.',
-    icon: FolderOpen,
-    accent: 'from-purple-500/10 via-purple-500/5 to-transparent',
-  },
-  team: {
-    title: 'Team Performance',
-    description: 'Utilization, output, and collaboration across your crew.',
-    icon: Users,
-    accent: 'from-emerald-500/10 via-emerald-500/5 to-transparent',
-  },
-  automation: {
-    title: 'Automation Footprint',
-    description: 'Tool coverage, run health, and cost impact.',
-    icon: Wrench,
-    accent: 'from-amber-500/10 via-amber-500/5 to-transparent',
-  },
-};
-
-type MetricCategory = keyof typeof CATEGORY_METADATA;
 
 type MetricDetailStat = {
   label: string;
@@ -1264,7 +1227,7 @@ const sanitizeCategorySelection = (selection: string[], category: MetricCategory
 const sanitizeSelections = (
   selections: Partial<Record<MetricCategory, string[]>>
 ): Record<MetricCategory, string[]> => {
-  return (Object.keys(CATEGORY_METADATA) as MetricCategory[]).reduce((acc, category) => {
+  return CATEGORY_ORDER.reduce((acc, category) => {
     const current = selections[category] ?? DEFAULT_METRIC_SELECTIONS[category];
     acc[category] = sanitizeCategorySelection(current, category);
     return acc;
@@ -2021,7 +1984,7 @@ const Dashboard: React.FC = () => {
       </section>
 
       <div className="space-y-6">
-        {(Object.keys(CATEGORY_METADATA) as MetricCategory[]).map((category) => {
+        {CATEGORY_ORDER.map((category) => {
           const metadata = CATEGORY_METADATA[category];
           const SectionIcon = metadata.icon;
           const selections = selectedMetrics[category] ?? DEFAULT_METRIC_SELECTIONS[category];

--- a/src/views/__tests__/dashboardCategories.test.ts
+++ b/src/views/__tests__/dashboardCategories.test.ts
@@ -1,0 +1,37 @@
+import type { MetricCategory } from '../dashboardCategories';
+
+const assert = (condition: boolean, message: string) => {
+  if (!condition) {
+    throw new Error(message);
+  }
+};
+
+const run = async () => {
+  const { CATEGORY_METADATA, CATEGORY_ORDER } = await import('../dashboardCategories.js');
+
+  const expectedOrder = ['projects', 'automation', 'clients', 'team'];
+  const orderMatches =
+    CATEGORY_ORDER.length === expectedOrder.length &&
+    CATEGORY_ORDER.every((category: MetricCategory, index: number) => category === expectedOrder[index]);
+
+  assert(orderMatches, 'Dashboard categories should render in the order Projects, Systems, Clients, then Team.');
+
+  const renderedTitles = CATEGORY_ORDER.map(
+    (category: MetricCategory) => CATEGORY_METADATA[category].title,
+  );
+  const expectedTitles = ['Projects', 'Systems', 'Clients', 'Team'];
+
+  expectedTitles.forEach((title, index) => {
+    assert(
+      renderedTitles[index] === title,
+      `Expected "${expectedOrder[index]}" title to be "${title}", received "${renderedTitles[index]}".`,
+    );
+  });
+
+  console.log('dashboardCategories tests passed');
+};
+
+run().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/src/views/dashboardCategories.ts
+++ b/src/views/dashboardCategories.ts
@@ -1,0 +1,42 @@
+import type { LucideIcon } from 'lucide-react';
+import { FolderOpen, Handshake, Users, Wrench } from 'lucide-react';
+
+export type MetricCategory = 'clients' | 'projects' | 'team' | 'automation';
+
+export type MetricCategoryMetadata = {
+  title: string;
+  description: string;
+  icon: LucideIcon;
+  accent: string;
+};
+
+export type CategoryMetadataRecord = Record<MetricCategory, MetricCategoryMetadata>;
+
+export const CATEGORY_METADATA: CategoryMetadataRecord = {
+  clients: {
+    title: 'Clients',
+    description: 'Pipeline health, relationships, and commercial momentum.',
+    icon: Handshake,
+    accent: 'from-sky-500/10 via-sky-500/5 to-transparent',
+  },
+  projects: {
+    title: 'Projects',
+    description: 'Monitor how projects move from planning through deployment.',
+    icon: FolderOpen,
+    accent: 'from-purple-500/10 via-purple-500/5 to-transparent',
+  },
+  team: {
+    title: 'Team',
+    description: 'Utilization, output, and collaboration across your crew.',
+    icon: Users,
+    accent: 'from-emerald-500/10 via-emerald-500/5 to-transparent',
+  },
+  automation: {
+    title: 'Systems',
+    description: 'Automation coverage, system health, and cost impact.',
+    icon: Wrench,
+    accent: 'from-amber-500/10 via-amber-500/5 to-transparent',
+  },
+};
+
+export const CATEGORY_ORDER: MetricCategory[] = ['projects', 'automation', 'clients', 'team'];

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -11,6 +11,8 @@
   "include": [
     "src/types/**/*.ts",
     "src/views/solutionsFilters.ts",
-    "src/views/__tests__/solutionsFilters.test.ts"
+    "src/views/dashboardCategories.ts",
+    "src/views/__tests__/solutionsFilters.test.ts",
+    "src/views/__tests__/dashboardCategories.test.ts"
   ]
 }


### PR DESCRIPTION
## Summary
- centralize dashboard category metadata with the updated Clients, Projects, Team, and Systems titles
- iterate through the dashboard cards via a shared CATEGORY_ORDER so sections render as Projects, Systems, Clients, then Team
- add a dashboard category test and update the TypeScript test build configuration so the new ordering is covered

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d1aaefcd38832d9ce950b3bdc48aca