### PR TITLE
Hide metric views from sidebar navigation

### DIFF
--- a/src/components/Layout/Sidebar.tsx
+++ b/src/components/Layout/Sidebar.tsx
@@ -16,7 +16,9 @@ const Sidebar: React.FC<SidebarProps> = ({ activeView, availablePages, onViewCha
 
   if (!user || !account) return null;
 
-  const menuItems = NAVIGATION_ITEMS.filter((item) => availablePages.includes(item.id));
+  const menuItems = NAVIGATION_ITEMS.filter(
+    (item) => item.showInSidebar !== false && availablePages.includes(item.id),
+  );
 
   return (
     <div className="w-64 flex-shrink-0 bg-[var(--bg-start)] border-r border-[var(--border)] flex flex-col sticky top-20 h-[calc(100vh-5rem)]">

--- a/src/lib/navigation.ts
+++ b/src/lib/navigation.ts
@@ -4,10 +4,10 @@ import type { NavigationItem, ViewId } from '../types/navigation';
 
 export const NAVIGATION_ITEMS: NavigationItem[] = [
   { id: 'dashboard', label: 'Dashboard', icon: LayoutDashboard },
-  { id: 'projects-metrics', label: 'Project Metrics', icon: FolderOpen },
-  { id: 'systems-metrics', label: 'Systems Metrics', icon: Wrench },
-  { id: 'clients-metrics', label: 'Client Metrics', icon: Handshake },
-  { id: 'team-metrics', label: 'Team Metrics', icon: Users },
+  { id: 'projects-metrics', label: 'Project Metrics', icon: FolderOpen, showInSidebar: false },
+  { id: 'systems-metrics', label: 'Systems Metrics', icon: Wrench, showInSidebar: false },
+  { id: 'clients-metrics', label: 'Client Metrics', icon: Handshake, showInSidebar: false },
+  { id: 'team-metrics', label: 'Team Metrics', icon: Users, showInSidebar: false },
   { id: 'workspaces', label: 'Workspaces', icon: PanelsTopLeft },
   { id: 'solutions', label: 'Solutions Hub', icon: Share2 },
 ];

--- a/src/types/navigation.ts
+++ b/src/types/navigation.ts
@@ -17,4 +17,9 @@ export interface NavigationItem {
   id: ViewId;
   label: string;
   icon: LucideIcon;
+  /**
+   * Controls whether the item should render in the sidebar navigation. Defaults to true when
+   * omitted so existing entries continue to appear unless explicitly hidden.
+   */
+  showInSidebar?: boolean;
 }


### PR DESCRIPTION
## Summary
- add an optional `showInSidebar` flag to navigation items to control sidebar visibility
- mark the four metric views as hidden from the sidebar while keeping them available for routing
- update the sidebar menu filter to respect the new visibility flag

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d361ac0efc83208387f59c298c6425