### PR TITLE
Simplify metrics views to focus on catalog

### DIFF
--- a/src/views/ClientsMetrics.tsx
+++ b/src/views/ClientsMetrics.tsx
@@ -1,108 +1,19 @@
 import React, { useMemo, useState } from 'react';
-import { Building2, RefreshCw, Search, Tags } from 'lucide-react';
+import { Building2 } from 'lucide-react';
 
 import MetricCatalogCard from './components/MetricCatalogCard';
 import { MetricDetailModal } from './Dashboard';
 import {
-  computeClientAnalytics,
   computeMetricsForCategory,
   metricCatalog,
   useMetricAnalytics,
 } from './metrics';
 import { CATEGORY_METADATA } from './dashboardCategories';
-import { Card } from '../components/Shared/Card';
 import type { ViewComponentProps } from '../types/navigation';
-import type { Client } from '../types';
-
-type ClientStatusFilter = 'all' | Client['status'];
-type TimeRangeValue = '30d' | '90d' | '365d' | 'all';
-
-const STATUS_OPTIONS: Array<{ value: ClientStatusFilter; label: string }> = [
-  { value: 'all', label: 'All statuses' },
-  { value: 'active', label: 'Active' },
-  { value: 'inactive', label: 'Inactive' },
-  { value: 'prospect', label: 'Prospect' },
-];
-
-const TIME_RANGE_OPTIONS: Array<{ value: TimeRangeValue; label: string }> = [
-  { value: '30d', label: 'Last 30 days' },
-  { value: '90d', label: 'Last 90 days' },
-  { value: '365d', label: 'Last 12 months' },
-  { value: 'all', label: 'All time' },
-];
-
-const isWithinTimeRange = (dateString: string | undefined, range: TimeRangeValue): boolean => {
-  if (range === 'all') {
-    return true;
-  }
-
-  const days = range === '30d' ? 30 : range === '90d' ? 90 : 365;
-  const threshold = Date.now() - days * 24 * 60 * 60 * 1000;
-  if (!dateString) {
-    return true;
-  }
-
-  const timestamp = Date.parse(dateString);
-  if (Number.isNaN(timestamp)) {
-    return true;
-  }
-
-  return timestamp >= threshold;
-};
 
 const ClientsMetrics: React.FC<ViewComponentProps> = () => {
-  const { clients, projectAnalytics, teamAnalytics, automationAnalytics } = useMetricAnalytics();
-
-  const [statusFilter, setStatusFilter] = useState<ClientStatusFilter>('all');
-  const [timeRange, setTimeRange] = useState<TimeRangeValue>('90d');
-  const [searchTerm, setSearchTerm] = useState('');
-  const [industryFilter, setIndustryFilter] = useState<'all' | string>('all');
+  const { analyticsContext } = useMetricAnalytics();
   const [activeMetricId, setActiveMetricId] = useState<string | null>(null);
-
-  const industryOptions = useMemo(() => {
-    const industries = Array.from(new Set(clients.map((client) => client.industry))).sort();
-    return ['all', ...industries];
-  }, [clients]);
-
-  const filteredClients = useMemo(() => {
-    const normalizedSearch = searchTerm.trim().toLowerCase();
-
-    return clients.filter((client) => {
-      if (statusFilter !== 'all' && client.status !== statusFilter) {
-        return false;
-      }
-
-      if (industryFilter !== 'all' && client.industry !== industryFilter) {
-        return false;
-      }
-
-      if (normalizedSearch && !client.companyName.toLowerCase().includes(normalizedSearch)) {
-        return false;
-      }
-
-      const dateToCheck = client.updatedAt ?? client.createdAt;
-      if (!isWithinTimeRange(dateToCheck, timeRange)) {
-        return false;
-      }
-
-      return true;
-    });
-  }, [clients, statusFilter, industryFilter, searchTerm, timeRange]);
-
-  const filteredClientAnalytics = useMemo(
-    () => computeClientAnalytics(filteredClients),
-    [filteredClients],
-  );
-
-  const analyticsContext = useMemo(
-    () => ({
-      clients: filteredClientAnalytics,
-      projects: projectAnalytics,
-      team: teamAnalytics,
-      automation: automationAnalytics,
-    }),
-    [filteredClientAnalytics, projectAnalytics, teamAnalytics, automationAnalytics],
-  );
 
   const clientMetrics = useMemo(
     () => computeMetricsForCategory(analyticsContext, 'clients'),
@@ -112,11 +23,6 @@ const ClientsMetrics: React.FC<ViewComponentProps> = () => {
   const activeMetric = activeMetricId ? clientMetrics[activeMetricId] ?? null : null;
   const clientsMetadata = CATEGORY_METADATA.clients;
 
-  const totalClients = clients.length;
-  const filteredCount = filteredClients.length;
-
-  const topRevenueClients = filteredClientAnalytics.topRevenueClients;
-
   return (
     <div className="space-y-8">
       <header className="flex flex-col gap-2">
@@ -125,120 +31,9 @@ const ClientsMetrics: React.FC<ViewComponentProps> = () => {
           <h1 className="text-2xl font-semibold">Client portfolio metrics</h1>
         </div>
         <p className="text-sm text-[var(--fg-muted)]">
-          Dive into revenue, satisfaction, and lifecycle metrics for every client relationship with targeted filters.
+          Dive into revenue, satisfaction, and lifecycle metrics for every client relationship.
         </p>
       </header>
-
-      <Card className="space-y-4 border-[var(--border)] bg-[var(--surface)] p-6">
-        <div className="flex items-center justify-between gap-4">
-          <h2 className="text-lg font-semibold text-[var(--fg)]">Filter clients</h2>
-          <button
-            type="button"
-            onClick={() => {
-              setStatusFilter('all');
-              setTimeRange('90d');
-              setSearchTerm('');
-              setIndustryFilter('all');
-            }}
-            className="inline-flex items-center gap-2 rounded-lg border border-[var(--border)] px-3 py-2 text-sm text-[var(--fg-muted)] transition-colors hover:text-[var(--fg)]"
-          >
-            <RefreshCw className="h-4 w-4" />
-            Reset
-          </button>
-        </div>
-        <div className="grid grid-cols-1 gap-4 md:grid-cols-4">
-          <label className="space-y-1 text-sm text-[var(--fg-muted)]">
-            <span className="font-medium text-[var(--fg)]">Client status</span>
-            <select
-              className="w-full rounded-lg border border-[var(--border)] bg-[var(--surface)] px-3 py-2 text-[var(--fg)] focus:outline-none"
-              value={statusFilter}
-              onChange={(event) => setStatusFilter(event.target.value as ClientStatusFilter)}
-            >
-              {STATUS_OPTIONS.map((option) => (
-                <option key={option.value} value={option.value}>
-                  {option.label}
-                </option>
-              ))}
-            </select>
-          </label>
-          <label className="space-y-1 text-sm text-[var(--fg-muted)]">
-            <span className="font-medium text-[var(--fg)]">Industry</span>
-            <select
-              className="w-full rounded-lg border border-[var(--border)] bg-[var(--surface)] px-3 py-2 text-[var(--fg)] focus:outline-none"
-              value={industryFilter}
-              onChange={(event) => setIndustryFilter(event.target.value as 'all' | string)}
-            >
-              {industryOptions.map((industry) => (
-                <option key={industry} value={industry}>
-                  {industry === 'all' ? 'All industries' : industry}
-                </option>
-              ))}
-            </select>
-          </label>
-          <label className="space-y-1 text-sm text-[var(--fg-muted)]">
-            <span className="font-medium text-[var(--fg)]">Time range</span>
-            <select
-              className="w-full rounded-lg border border-[var(--border)] bg-[var(--surface)] px-3 py-2 text-[var(--fg)] focus:outline-none"
-              value={timeRange}
-              onChange={(event) => setTimeRange(event.target.value as TimeRangeValue)}
-            >
-              {TIME_RANGE_OPTIONS.map((option) => (
-                <option key={option.value} value={option.value}>
-                  {option.label}
-                </option>
-              ))}
-            </select>
-          </label>
-          <label className="space-y-1 text-sm text-[var(--fg-muted)]">
-            <span className="font-medium text-[var(--fg)]">Client name</span>
-            <div className="flex items-center gap-2 rounded-lg border border-[var(--border)] bg-[var(--surface)] px-3 py-2">
-              <Search className="h-4 w-4 text-[var(--fg-muted)]" />
-              <input
-                type="text"
-                value={searchTerm}
-                onChange={(event) => setSearchTerm(event.target.value)}
-                placeholder="Search by organization"
-                className="flex-1 bg-transparent text-sm text-[var(--fg)] focus:outline-none"
-              />
-            </div>
-          </label>
-        </div>
-      </Card>
-
-      <Card className="space-y-4 border-[var(--border)] bg-[var(--surface)] p-6">
-        <div className="flex flex-col gap-2 sm:flex-row sm:items-baseline sm:justify-between">
-          <div>
-            <p className="text-xs font-semibold uppercase tracking-wide text-[var(--fg-muted)]">Filtered clients</p>
-            <p className="text-lg font-semibold text-[var(--fg)]">
-              {filteredCount} of {totalClients} accounts
-            </p>
-          </div>
-          <div className="inline-flex items-center gap-2 rounded-full bg-[var(--surface-elevated)] px-3 py-1 text-sm text-[var(--fg-muted)]">
-            <Tags className="h-4 w-4" />
-            {industryFilter === 'all' ? 'All industries' : industryFilter}
-          </div>
-        </div>
-        {filteredCount > 0 ? (
-          <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
-            {topRevenueClients.slice(0, 4).map((client) => (
-              <div
-                key={client.id}
-                className="rounded-xl border border-[var(--border)] bg-[var(--surface-elevated)] px-4 py-3"
-              >
-                <div className="flex items-center justify-between gap-3">
-                  <div>
-                    <p className="text-sm font-semibold text-[var(--fg)]">{client.name}</p>
-                    <p className="text-xs text-[var(--fg-muted)]">${client.revenue.toLocaleString()} revenue</p>
-                  </div>
-                  <span className="text-xs text-[var(--fg-muted)]">{client.status}</span>
-                </div>
-              </div>
-            ))}
-          </div>
-        ) : (
-          <p className="text-sm text-[var(--fg-muted)]">No clients match the selected filters yet.</p>
-        )}
-      </Card>
 
       <section className="space-y-4">
         <div className="flex flex-col gap-2">

--- a/src/views/ProjectsMetrics.tsx
+++ b/src/views/ProjectsMetrics.tsx
@@ -1,102 +1,19 @@
 import React, { useMemo, useState } from 'react';
-import { Clock, FolderOpen, RefreshCw, Search } from 'lucide-react';
+import { FolderOpen } from 'lucide-react';
 
 import MetricCatalogCard from './components/MetricCatalogCard';
 import { MetricDetailModal } from './Dashboard';
 import {
-  computeClientAnalytics,
   computeMetricsForCategory,
-  computeProjectAnalytics,
   metricCatalog,
   useMetricAnalytics,
 } from './metrics';
 import { CATEGORY_METADATA } from './dashboardCategories';
-import { Card } from '../components/Shared/Card';
 import type { ViewComponentProps } from '../types/navigation';
-import type { Project } from '../types';
-
-const PROJECT_STATUS_OPTIONS: Array<{ value: 'all' | Project['status']; label: string }> = [
-  { value: 'all', label: 'All statuses' },
-  { value: 'planning', label: 'Planning' },
-  { value: 'development', label: 'Development' },
-  { value: 'testing', label: 'Testing' },
-  { value: 'deployed', label: 'Deployed' },
-  { value: 'maintenance', label: 'Maintenance' },
-];
-
-type TimeRangeValue = '30d' | '90d' | '365d' | 'all';
-
-const TIME_RANGE_OPTIONS: Array<{ value: TimeRangeValue; label: string }> = [
-  { value: '30d', label: 'Last 30 days' },
-  { value: '90d', label: 'Last 90 days' },
-  { value: '365d', label: 'Last 12 months' },
-  { value: 'all', label: 'All time' },
-];
-
-const isWithinTimeRange = (dateString: string | undefined, range: TimeRangeValue): boolean => {
-  if (range === 'all') {
-    return true;
-  }
-
-  const days = range === '30d' ? 30 : range === '90d' ? 90 : 365;
-  const threshold = Date.now() - days * 24 * 60 * 60 * 1000;
-  if (!dateString) {
-    return true;
-  }
-
-  const timestamp = Date.parse(dateString);
-  if (Number.isNaN(timestamp)) {
-    return true;
-  }
-
-  return timestamp >= threshold;
-};
 
 const ProjectsMetrics: React.FC<ViewComponentProps> = () => {
-  const { clients, projects, teamAnalytics, automationAnalytics } = useMetricAnalytics();
-
-  const [statusFilter, setStatusFilter] = useState<'all' | Project['status']>('all');
-  const [timeRange, setTimeRange] = useState<TimeRangeValue>('90d');
-  const [searchTerm, setSearchTerm] = useState('');
+  const { analyticsContext } = useMetricAnalytics();
   const [activeMetricId, setActiveMetricId] = useState<string | null>(null);
-
-  const filteredProjects = useMemo(() => {
-    const normalizedSearch = searchTerm.trim().toLowerCase();
-
-    return projects.filter((project) => {
-      if (statusFilter !== 'all' && project.status !== statusFilter) {
-        return false;
-      }
-
-      if (normalizedSearch && !project.name.toLowerCase().includes(normalizedSearch)) {
-        return false;
-      }
-
-      const dateToCheck = project.updatedAt ?? project.createdAt;
-      if (!isWithinTimeRange(dateToCheck, timeRange)) {
-        return false;
-      }
-
-      return true;
-    });
-  }, [projects, statusFilter, searchTerm, timeRange]);
-
-  const filteredClients = useMemo(() => {
-    const projectClientIds = new Set(filteredProjects.map((project) => project.clientId));
-    return clients.filter((client) => projectClientIds.has(client.id));
-  }, [clients, filteredProjects]);
-
-  const analyticsContext = useMemo(() => {
-    const projectAnalytics = computeProjectAnalytics(filteredProjects);
-    const clientAnalytics = computeClientAnalytics(filteredClients);
-
-    return {
-      clients: clientAnalytics,
-      projects: projectAnalytics,
-      team: teamAnalytics,
-      automation: automationAnalytics,
-    };
-  }, [filteredClients, filteredProjects, teamAnalytics, automationAnalytics]);
 
   const projectMetrics = useMemo(
     () => computeMetricsForCategory(analyticsContext, 'projects'),
@@ -106,17 +23,6 @@ const ProjectsMetrics: React.FC<ViewComponentProps> = () => {
   const activeMetric = activeMetricId ? projectMetrics[activeMetricId] ?? null : null;
 
   const projectsMetadata = CATEGORY_METADATA.projects;
-  const totalProjects = projects.length;
-  const filteredCount = filteredProjects.length;
-
-  const topProjects = useMemo(
-    () =>
-      filteredProjects
-        .slice()
-        .sort((a, b) => Date.parse(b.updatedAt ?? b.createdAt) - Date.parse(a.updatedAt ?? a.createdAt))
-        .slice(0, 5),
-    [filteredProjects],
-  );
 
   return (
     <div className="space-y-8">
@@ -126,109 +32,9 @@ const ProjectsMetrics: React.FC<ViewComponentProps> = () => {
           <h1 className="text-2xl font-semibold">Project delivery metrics</h1>
         </div>
         <p className="text-sm text-[var(--fg-muted)]">
-          Explore the full catalog of project delivery metrics with focused filters for status, time range, and specific engagements.
+          Explore the complete catalog of project delivery metrics with detailed insights for every engagement.
         </p>
       </header>
-
-      <Card className="space-y-4 border-[var(--border)] bg-[var(--surface)] p-6">
-        <div className="flex items-center justify-between gap-4">
-          <h2 className="text-lg font-semibold text-[var(--fg)]">Filter projects</h2>
-          <button
-            type="button"
-            onClick={() => {
-              setStatusFilter('all');
-              setTimeRange('90d');
-              setSearchTerm('');
-            }}
-            className="inline-flex items-center gap-2 rounded-lg border border-[var(--border)] px-3 py-2 text-sm text-[var(--fg-muted)] transition-colors hover:text-[var(--fg)]"
-          >
-            <RefreshCw className="h-4 w-4" />
-            Reset
-          </button>
-        </div>
-        <div className="grid grid-cols-1 gap-4 md:grid-cols-4">
-          <label className="space-y-1 text-sm text-[var(--fg-muted)]">
-            <span className="font-medium text-[var(--fg)]">Project status</span>
-            <select
-              className="w-full rounded-lg border border-[var(--border)] bg-[var(--surface)] px-3 py-2 text-[var(--fg)] focus:outline-none"
-              value={statusFilter}
-              onChange={(event) => setStatusFilter(event.target.value as 'all' | Project['status'])}
-            >
-              {PROJECT_STATUS_OPTIONS.map((option) => (
-                <option key={option.value} value={option.value}>
-                  {option.label}
-                </option>
-              ))}
-            </select>
-          </label>
-          <label className="space-y-1 text-sm text-[var(--fg-muted)]">
-            <span className="font-medium text-[var(--fg)]">Time range</span>
-            <select
-              className="w-full rounded-lg border border-[var(--border)] bg-[var(--surface)] px-3 py-2 text-[var(--fg)] focus:outline-none"
-              value={timeRange}
-              onChange={(event) => setTimeRange(event.target.value as TimeRangeValue)}
-            >
-              {TIME_RANGE_OPTIONS.map((option) => (
-                <option key={option.value} value={option.value}>
-                  {option.label}
-                </option>
-              ))}
-            </select>
-          </label>
-          <label className="space-y-1 text-sm text-[var(--fg-muted)] md:col-span-2">
-            <span className="font-medium text-[var(--fg)]">Project name</span>
-            <div className="flex items-center gap-2 rounded-lg border border-[var(--border)] bg-[var(--surface)] px-3 py-2">
-              <Search className="h-4 w-4 text-[var(--fg-muted)]" />
-              <input
-                type="text"
-                value={searchTerm}
-                onChange={(event) => setSearchTerm(event.target.value)}
-                placeholder="Search by project title"
-                className="flex-1 bg-transparent text-sm text-[var(--fg)] focus:outline-none"
-              />
-            </div>
-          </label>
-        </div>
-      </Card>
-
-      <Card className="space-y-4 border-[var(--border)] bg-[var(--surface)] p-6">
-        <div className="flex flex-col gap-2 sm:flex-row sm:items-baseline sm:justify-between">
-          <div>
-            <p className="text-xs font-semibold uppercase tracking-wide text-[var(--fg-muted)]">Filtered scope</p>
-            <p className="text-lg font-semibold text-[var(--fg)]">
-              {filteredCount} of {totalProjects} projects
-            </p>
-          </div>
-          <div className="inline-flex items-center gap-2 rounded-full bg-[var(--surface-elevated)] px-3 py-1 text-sm text-[var(--fg-muted)]">
-            <Clock className="h-4 w-4" />
-            {TIME_RANGE_OPTIONS.find((option) => option.value === timeRange)?.label ?? 'All time'}
-          </div>
-        </div>
-        {topProjects.length > 0 ? (
-          <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
-            {topProjects.map((project) => (
-              <div
-                key={project.id}
-                className="rounded-xl border border-[var(--border)] bg-[var(--surface-elevated)] px-4 py-3"
-              >
-                <div className="flex items-center justify-between gap-3">
-                  <div>
-                    <p className="text-sm font-semibold text-[var(--fg)]">{project.name}</p>
-                    <p className="text-xs text-[var(--fg-muted)]">{project.status}</p>
-                  </div>
-                  <span className="text-xs text-[var(--fg-muted)]">
-                    Updated {new Date(project.updatedAt ?? project.createdAt).toLocaleDateString()}
-                  </span>
-                </div>
-              </div>
-            ))}
-          </div>
-        ) : (
-          <p className="text-sm text-[var(--fg-muted)]">
-            No projects match the selected filters yet.
-          </p>
-        )}
-      </Card>
 
       <section className="space-y-4">
         <div className="flex flex-col gap-2">

--- a/src/views/SystemsMetrics.tsx
+++ b/src/views/SystemsMetrics.tsx
@@ -1,114 +1,19 @@
 import React, { useMemo, useState } from 'react';
-import { Cpu, RefreshCw, Search, SlidersHorizontal } from 'lucide-react';
+import { Cpu } from 'lucide-react';
 
 import MetricCatalogCard from './components/MetricCatalogCard';
 import { MetricDetailModal } from './Dashboard';
 import {
-  computeAutomationAnalytics,
   computeMetricsForCategory,
   metricCatalog,
   useMetricAnalytics,
 } from './metrics';
 import { CATEGORY_METADATA } from './dashboardCategories';
-import { Card } from '../components/Shared/Card';
 import type { ViewComponentProps } from '../types/navigation';
-import type { Tool } from '../types/tools';
-
-type TimeRangeValue = '30d' | '90d' | '365d' | 'all';
-
-type ToolStatusFilter = 'all' | Tool['status'];
-type ToolCategoryFilter = 'all' | Tool['category'];
-
-const TIME_RANGE_OPTIONS: Array<{ value: TimeRangeValue; label: string }> = [
-  { value: '30d', label: 'Last 30 days' },
-  { value: '90d', label: 'Last 90 days' },
-  { value: '365d', label: 'Last 12 months' },
-  { value: 'all', label: 'All time' },
-];
-
-const STATUS_OPTIONS: Array<{ value: ToolStatusFilter; label: string }> = [
-  { value: 'all', label: 'All statuses' },
-  { value: 'active', label: 'Active' },
-  { value: 'development', label: 'Development' },
-  { value: 'testing', label: 'Testing' },
-  { value: 'inactive', label: 'Inactive' },
-  { value: 'error', label: 'Error' },
-];
-
-const TYPE_OPTIONS: Array<{ value: ToolCategoryFilter; label: string }> = [
-  { value: 'all', label: 'All categories' },
-  { value: 'ML', label: 'ML' },
-  { value: 'LLM', label: 'LLM' },
-  { value: 'GPT', label: 'GPT' },
-  { value: 'AI Tool', label: 'AI Tool' },
-  { value: 'Agent', label: 'Agent' },
-  { value: 'Automation', label: 'Automation' },
-  { value: 'Workflow', label: 'Workflow' },
-];
-
-const isWithinTimeRange = (dateString: string | undefined, range: TimeRangeValue): boolean => {
-  if (range === 'all') {
-    return true;
-  }
-
-  const days = range === '30d' ? 30 : range === '90d' ? 90 : 365;
-  const threshold = Date.now() - days * 24 * 60 * 60 * 1000;
-  if (!dateString) {
-    return true;
-  }
-
-  const timestamp = Date.parse(dateString);
-  if (Number.isNaN(timestamp)) {
-    return true;
-  }
-
-  return timestamp >= threshold;
-};
 
 const SystemsMetrics: React.FC<ViewComponentProps> = () => {
-  const { tools, clientAnalytics, projectAnalytics, teamAnalytics } = useMetricAnalytics();
-
-  const [statusFilter, setStatusFilter] = useState<ToolStatusFilter>('all');
-  const [typeFilter, setTypeFilter] = useState<ToolCategoryFilter>('all');
-  const [timeRange, setTimeRange] = useState<TimeRangeValue>('90d');
-  const [searchTerm, setSearchTerm] = useState('');
+  const { analyticsContext } = useMetricAnalytics();
   const [activeMetricId, setActiveMetricId] = useState<string | null>(null);
-
-  const filteredTools = useMemo(() => {
-    const normalizedSearch = searchTerm.trim().toLowerCase();
-
-    return tools.filter((tool) => {
-      if (statusFilter !== 'all' && tool.status !== statusFilter) {
-        return false;
-      }
-
-      if (typeFilter !== 'all' && tool.category !== typeFilter) {
-        return false;
-      }
-
-      if (normalizedSearch && !tool.name.toLowerCase().includes(normalizedSearch)) {
-        return false;
-      }
-
-      const dateToCheck = tool.updatedAt ?? tool.createdAt;
-      if (!isWithinTimeRange(dateToCheck, timeRange)) {
-        return false;
-      }
-
-      return true;
-    });
-  }, [tools, statusFilter, typeFilter, timeRange, searchTerm]);
-
-  const analyticsContext = useMemo(() => {
-    const automationAnalytics = computeAutomationAnalytics(filteredTools);
-
-    return {
-      clients: clientAnalytics,
-      projects: projectAnalytics,
-      team: teamAnalytics,
-      automation: automationAnalytics,
-    };
-  }, [filteredTools, clientAnalytics, projectAnalytics, teamAnalytics]);
 
   const automationMetrics = useMemo(
     () => computeMetricsForCategory(analyticsContext, 'automation'),
@@ -118,18 +23,6 @@ const SystemsMetrics: React.FC<ViewComponentProps> = () => {
   const activeMetric = activeMetricId ? automationMetrics[activeMetricId] ?? null : null;
   const systemsMetadata = CATEGORY_METADATA.automation;
 
-  const totalTools = tools.length;
-  const filteredCount = filteredTools.length;
-
-  const topSystems = useMemo(
-    () =>
-      filteredTools
-        .slice()
-        .sort((a, b) => (b.stats?.usage ?? 0) - (a.stats?.usage ?? 0))
-        .slice(0, 6),
-    [filteredTools],
-  );
-
   return (
     <div className="space-y-8">
       <header className="flex flex-col gap-2">
@@ -138,120 +31,9 @@ const SystemsMetrics: React.FC<ViewComponentProps> = () => {
           <h1 className="text-2xl font-semibold">Automation systems metrics</h1>
         </div>
         <p className="text-sm text-[var(--fg-muted)]">
-          Audit automation and AI systems with granular filters for status, deployment recency, and platform category.
+          Audit automation and AI systems with comprehensive insight into performance, reliability, and adoption.
         </p>
       </header>
-
-      <Card className="space-y-4 border-[var(--border)] bg-[var(--surface)] p-6">
-        <div className="flex items-center justify-between gap-4">
-          <h2 className="text-lg font-semibold text-[var(--fg)]">Filter systems</h2>
-          <button
-            type="button"
-            onClick={() => {
-              setStatusFilter('all');
-              setTypeFilter('all');
-              setTimeRange('90d');
-              setSearchTerm('');
-            }}
-            className="inline-flex items-center gap-2 rounded-lg border border-[var(--border)] px-3 py-2 text-sm text-[var(--fg-muted)] transition-colors hover:text-[var(--fg)]"
-          >
-            <RefreshCw className="h-4 w-4" />
-            Reset
-          </button>
-        </div>
-        <div className="grid grid-cols-1 gap-4 md:grid-cols-4">
-          <label className="space-y-1 text-sm text-[var(--fg-muted)]">
-            <span className="font-medium text-[var(--fg)]">System status</span>
-            <select
-              className="w-full rounded-lg border border-[var(--border)] bg-[var(--surface)] px-3 py-2 text-[var(--fg)] focus:outline-none"
-              value={statusFilter}
-              onChange={(event) => setStatusFilter(event.target.value as ToolStatusFilter)}
-            >
-              {STATUS_OPTIONS.map((option) => (
-                <option key={option.value} value={option.value}>
-                  {option.label}
-                </option>
-              ))}
-            </select>
-          </label>
-          <label className="space-y-1 text-sm text-[var(--fg-muted)]">
-            <span className="font-medium text-[var(--fg)]">System category</span>
-            <select
-              className="w-full rounded-lg border border-[var(--border)] bg-[var(--surface)] px-3 py-2 text-[var(--fg)] focus:outline-none"
-              value={typeFilter}
-              onChange={(event) => setTypeFilter(event.target.value as ToolCategoryFilter)}
-            >
-              {TYPE_OPTIONS.map((option) => (
-                <option key={option.value} value={option.value}>
-                  {option.label}
-                </option>
-              ))}
-            </select>
-          </label>
-          <label className="space-y-1 text-sm text-[var(--fg-muted)]">
-            <span className="font-medium text-[var(--fg)]">Time range</span>
-            <select
-              className="w-full rounded-lg border border-[var(--border)] bg-[var(--surface)] px-3 py-2 text-[var(--fg)] focus:outline-none"
-              value={timeRange}
-              onChange={(event) => setTimeRange(event.target.value as TimeRangeValue)}
-            >
-              {TIME_RANGE_OPTIONS.map((option) => (
-                <option key={option.value} value={option.value}>
-                  {option.label}
-                </option>
-              ))}
-            </select>
-          </label>
-          <label className="space-y-1 text-sm text-[var(--fg-muted)]">
-            <span className="font-medium text-[var(--fg)]">System name</span>
-            <div className="flex items-center gap-2 rounded-lg border border-[var(--border)] bg-[var(--surface)] px-3 py-2">
-              <Search className="h-4 w-4 text-[var(--fg-muted)]" />
-              <input
-                type="text"
-                value={searchTerm}
-                onChange={(event) => setSearchTerm(event.target.value)}
-                placeholder="Search by system or project"
-                className="flex-1 bg-transparent text-sm text-[var(--fg)] focus:outline-none"
-              />
-            </div>
-          </label>
-        </div>
-      </Card>
-
-      <Card className="space-y-4 border-[var(--border)] bg-[var(--surface)] p-6">
-        <div className="flex flex-col gap-2 sm:flex-row sm:items-baseline sm:justify-between">
-          <div>
-            <p className="text-xs font-semibold uppercase tracking-wide text-[var(--fg-muted)]">Filtered systems</p>
-            <p className="text-lg font-semibold text-[var(--fg)]">
-              {filteredCount} of {totalTools} automations
-            </p>
-          </div>
-          <div className="inline-flex items-center gap-2 rounded-full bg-[var(--surface-elevated)] px-3 py-1 text-sm text-[var(--fg-muted)]">
-            <SlidersHorizontal className="h-4 w-4" />
-            {STATUS_OPTIONS.find((option) => option.value === statusFilter)?.label ?? 'All statuses'}
-          </div>
-        </div>
-        {topSystems.length > 0 ? (
-          <div className="grid grid-cols-1 gap-3 md:grid-cols-3">
-            {topSystems.map((tool) => (
-              <div
-                key={tool.id}
-                className="rounded-xl border border-[var(--border)] bg-[var(--surface-elevated)] px-4 py-3"
-              >
-                <div className="flex flex-col gap-1">
-                  <p className="text-sm font-semibold text-[var(--fg)]">{tool.name}</p>
-                  <p className="text-xs text-[var(--fg-muted)]">{tool.category} · {tool.status}</p>
-                  <p className="text-xs text-[var(--fg-muted)]">
-                    Usage {tool.stats?.usage ?? 0}% · Efficiency {tool.stats?.efficiency ?? 0}%
-                  </p>
-                </div>
-              </div>
-            ))}
-          </div>
-        ) : (
-          <p className="text-sm text-[var(--fg-muted)]">No systems match the selected filters at the moment.</p>
-        )}
-      </Card>
 
       <section className="space-y-4">
         <div className="flex flex-col gap-2">

--- a/src/views/TeamMetrics.tsx
+++ b/src/views/TeamMetrics.tsx
@@ -1,110 +1,19 @@
 import React, { useMemo, useState } from 'react';
-import { RefreshCw, Search, Users } from 'lucide-react';
+import { Users } from 'lucide-react';
 
 import MetricCatalogCard from './components/MetricCatalogCard';
 import { MetricDetailModal } from './Dashboard';
 import {
   computeMetricsForCategory,
-  computeTeamAnalytics,
   metricCatalog,
   useMetricAnalytics,
 } from './metrics';
 import { CATEGORY_METADATA } from './dashboardCategories';
-import { Card } from '../components/Shared/Card';
 import type { ViewComponentProps } from '../types/navigation';
-import type { TeamMember } from '../types';
-
-type TeamStatusFilter = 'all' | TeamMember['status'];
-type TeamTypeFilter = 'all' | TeamMember['type'];
-type TimeRangeValue = '30d' | '90d' | '365d' | 'all';
-
-const STATUS_OPTIONS: Array<{ value: TeamStatusFilter; label: string }> = [
-  { value: 'all', label: 'All statuses' },
-  { value: 'active', label: 'Active' },
-  { value: 'inactive', label: 'Inactive' },
-];
-
-const TYPE_OPTIONS: Array<{ value: TeamTypeFilter; label: string }> = [
-  { value: 'all', label: 'All types' },
-  { value: 'internal', label: 'Internal' },
-  { value: 'external', label: 'External' },
-  { value: 'inactive', label: 'Inactive' },
-];
-
-const TIME_RANGE_OPTIONS: Array<{ value: TimeRangeValue; label: string }> = [
-  { value: '30d', label: 'Last 30 days' },
-  { value: '90d', label: 'Last 90 days' },
-  { value: '365d', label: 'Last 12 months' },
-  { value: 'all', label: 'All time' },
-];
-
-const isWithinTimeRange = (dateString: string | undefined, range: TimeRangeValue): boolean => {
-  if (range === 'all') {
-    return true;
-  }
-
-  const days = range === '30d' ? 30 : range === '90d' ? 90 : 365;
-  const threshold = Date.now() - days * 24 * 60 * 60 * 1000;
-  if (!dateString) {
-    return true;
-  }
-
-  const timestamp = Date.parse(dateString);
-  if (Number.isNaN(timestamp)) {
-    return true;
-  }
-
-  return timestamp >= threshold;
-};
 
 const TeamMetrics: React.FC<ViewComponentProps> = () => {
-  const { teamMembers, clientAnalytics, projectAnalytics, automationAnalytics } = useMetricAnalytics();
-
-  const [statusFilter, setStatusFilter] = useState<TeamStatusFilter>('all');
-  const [typeFilter, setTypeFilter] = useState<TeamTypeFilter>('all');
-  const [timeRange, setTimeRange] = useState<TimeRangeValue>('90d');
-  const [searchTerm, setSearchTerm] = useState('');
+  const { analyticsContext } = useMetricAnalytics();
   const [activeMetricId, setActiveMetricId] = useState<string | null>(null);
-
-  const filteredTeamMembers = useMemo(() => {
-    const normalizedSearch = searchTerm.trim().toLowerCase();
-
-    return teamMembers.filter((member) => {
-      if (statusFilter !== 'all' && member.status !== statusFilter) {
-        return false;
-      }
-
-      if (typeFilter !== 'all' && member.type !== typeFilter) {
-        return false;
-      }
-
-      if (normalizedSearch && !member.name.toLowerCase().includes(normalizedSearch)) {
-        return false;
-      }
-
-      const dateToCheck = member.lastActiveAt ?? member.updatedAt;
-      if (!isWithinTimeRange(dateToCheck, timeRange)) {
-        return false;
-      }
-
-      return true;
-    });
-  }, [teamMembers, statusFilter, typeFilter, searchTerm, timeRange]);
-
-  const filteredTeamAnalytics = useMemo(
-    () => computeTeamAnalytics(filteredTeamMembers),
-    [filteredTeamMembers],
-  );
-
-  const analyticsContext = useMemo(
-    () => ({
-      clients: clientAnalytics,
-      projects: projectAnalytics,
-      team: filteredTeamAnalytics,
-      automation: automationAnalytics,
-    }),
-    [clientAnalytics, projectAnalytics, filteredTeamAnalytics, automationAnalytics],
-  );
 
   const teamMetrics = useMemo(
     () => computeMetricsForCategory(analyticsContext, 'team'),
@@ -113,11 +22,6 @@ const TeamMetrics: React.FC<ViewComponentProps> = () => {
 
   const activeMetric = activeMetricId ? teamMetrics[activeMetricId] ?? null : null;
   const teamMetadata = CATEGORY_METADATA.team;
-
-  const totalMembers = teamMembers.length;
-  const filteredCount = filteredTeamMembers.length;
-
-  const topContributors = filteredTeamAnalytics.topProductiveMembers;
 
   return (
     <div className="space-y-8">
@@ -130,118 +34,6 @@ const TeamMetrics: React.FC<ViewComponentProps> = () => {
           Track utilization, satisfaction, and enablement impact across every collaborator.
         </p>
       </header>
-
-      <Card className="space-y-4 border-[var(--border)] bg-[var(--surface)] p-6">
-        <div className="flex items-center justify-between gap-4">
-          <h2 className="text-lg font-semibold text-[var(--fg)]">Filter team members</h2>
-          <button
-            type="button"
-            onClick={() => {
-              setStatusFilter('all');
-              setTypeFilter('all');
-              setTimeRange('90d');
-              setSearchTerm('');
-            }}
-            className="inline-flex items-center gap-2 rounded-lg border border-[var(--border)] px-3 py-2 text-sm text-[var(--fg-muted)] transition-colors hover:text-[var(--fg)]"
-          >
-            <RefreshCw className="h-4 w-4" />
-            Reset
-          </button>
-        </div>
-        <div className="grid grid-cols-1 gap-4 md:grid-cols-4">
-          <label className="space-y-1 text-sm text-[var(--fg-muted)]">
-            <span className="font-medium text-[var(--fg)]">Team status</span>
-            <select
-              className="w-full rounded-lg border border-[var(--border)] bg-[var(--surface)] px-3 py-2 text-[var(--fg)] focus:outline-none"
-              value={statusFilter}
-              onChange={(event) => setStatusFilter(event.target.value as TeamStatusFilter)}
-            >
-              {STATUS_OPTIONS.map((option) => (
-                <option key={option.value} value={option.value}>
-                  {option.label}
-                </option>
-              ))}
-            </select>
-          </label>
-          <label className="space-y-1 text-sm text-[var(--fg-muted)]">
-            <span className="font-medium text-[var(--fg)]">Team type</span>
-            <select
-              className="w-full rounded-lg border border-[var(--border)] bg-[var(--surface)] px-3 py-2 text-[var(--fg)] focus:outline-none"
-              value={typeFilter}
-              onChange={(event) => setTypeFilter(event.target.value as TeamTypeFilter)}
-            >
-              {TYPE_OPTIONS.map((option) => (
-                <option key={option.value} value={option.value}>
-                  {option.label}
-                </option>
-              ))}
-            </select>
-          </label>
-          <label className="space-y-1 text-sm text-[var(--fg-muted)]">
-            <span className="font-medium text-[var(--fg)]">Time range</span>
-            <select
-              className="w-full rounded-lg border border-[var(--border)] bg-[var(--surface)] px-3 py-2 text-[var(--fg)] focus:outline-none"
-              value={timeRange}
-              onChange={(event) => setTimeRange(event.target.value as TimeRangeValue)}
-            >
-              {TIME_RANGE_OPTIONS.map((option) => (
-                <option key={option.value} value={option.value}>
-                  {option.label}
-                </option>
-              ))}
-            </select>
-          </label>
-          <label className="space-y-1 text-sm text-[var(--fg-muted)]">
-            <span className="font-medium text-[var(--fg)]">Team member</span>
-            <div className="flex items-center gap-2 rounded-lg border border-[var(--border)] bg-[var(--surface)] px-3 py-2">
-              <Search className="h-4 w-4 text-[var(--fg-muted)]" />
-              <input
-                type="text"
-                value={searchTerm}
-                onChange={(event) => setSearchTerm(event.target.value)}
-                placeholder="Search by name"
-                className="flex-1 bg-transparent text-sm text-[var(--fg)] focus:outline-none"
-              />
-            </div>
-          </label>
-        </div>
-      </Card>
-
-      <Card className="space-y-4 border-[var(--border)] bg-[var(--surface)] p-6">
-        <div className="flex flex-col gap-2 sm:flex-row sm:items-baseline sm:justify-between">
-          <div>
-            <p className="text-xs font-semibold uppercase tracking-wide text-[var(--fg-muted)]">Filtered collaborators</p>
-            <p className="text-lg font-semibold text-[var(--fg)]">
-              {filteredCount} of {totalMembers} teammates
-            </p>
-          </div>
-          <div className="inline-flex items-center gap-2 rounded-full bg-[var(--surface-elevated)] px-3 py-1 text-sm text-[var(--fg-muted)]">
-            {timeRange === 'all' ? 'All activity' : TIME_RANGE_OPTIONS.find((option) => option.value === timeRange)?.label}
-          </div>
-        </div>
-        {filteredCount > 0 ? (
-          <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
-            {topContributors.slice(0, 4).map((member) => (
-              <div
-                key={member.id}
-                className="rounded-xl border border-[var(--border)] bg-[var(--surface-elevated)] px-4 py-3"
-              >
-                <div className="flex items-center justify-between gap-3">
-                  <div>
-                    <p className="text-sm font-semibold text-[var(--fg)]">{member.name}</p>
-                    <p className="text-xs text-[var(--fg-muted)]">{member.role}</p>
-                  </div>
-                  <span className="text-xs text-[var(--fg-muted)]">
-                    Productivity {Math.round(member.productivity)}%
-                  </span>
-                </div>
-              </div>
-            ))}
-          </div>
-        ) : (
-          <p className="text-sm text-[var(--fg-muted)]">No team members match the selected filters yet.</p>
-        )}
-      </Card>
 
       <section className="space-y-4">
         <div className="flex flex-col gap-2">


### PR DESCRIPTION
## Summary
- remove filter and summary cards from metrics views so the layout focuses on the catalog flow
- streamline each metrics component to rely on the shared analytics context and metric catalog rendering

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d36ac053a083208e78cdd34fe1d57d