### PR TITLE
Ensure sidebar stays sticky and main panel handles overflow

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -68,7 +68,7 @@ const AppContent: React.FC = () => {
   return (
     <div className="min-h-screen flex flex-col bg-[var(--bg-start)]">
       <Header />
-      <div className="flex-1 flex">
+      <div className="flex-1 flex overflow-hidden">
         <Sidebar activeView={activeView} availablePages={availablePages} onViewChange={setActiveView} />
         <div className="flex-1 flex flex-col">
           <main className="flex-1 overflow-auto px-6 py-8 sm:px-8 sm:py-10 lg:px-12 lg:py-12">

--- a/src/components/Layout/Sidebar.tsx
+++ b/src/components/Layout/Sidebar.tsx
@@ -21,7 +21,7 @@ const Sidebar: React.FC<SidebarProps> = ({ activeView, availablePages, onViewCha
   );
 
   return (
-    <div className="h-full flex flex-col bg-[var(--bg)]">
+    <div className="w-72 flex-shrink-0 sticky top-20 h-[calc(100vh-5rem)] overflow-y-auto flex flex-col bg-[var(--bg)]">
       <nav className="flex-1 p-4">
         <ul className="space-y-2">
           {menuItems.map((item) => {


### PR DESCRIPTION
## Summary
- prevent the overall document from scrolling by constraining overflow to the main content wrapper
- update the sidebar container to have a fixed width and sticky positioning with its own scroll behavior

## Testing
- npm run dev


------
https://chatgpt.com/codex/tasks/task_e_68d374d014408320981a3591a5e9cd53