### PR TITLE
Fix sidebar menu positioning

### DIFF
--- a/src/components/Layout/Sidebar.tsx
+++ b/src/components/Layout/Sidebar.tsx
@@ -21,8 +21,8 @@ const Sidebar: React.FC<SidebarProps> = ({ activeView, availablePages, onViewCha
   );
 
   return (
-    <div className="w-72 flex-shrink-0 sticky top-20 h-[calc(100vh-5rem)] overflow-y-auto flex flex-col bg-[var(--bg)]">
-      <nav className="flex-1 p-4">
+    <div className="w-72 flex-shrink-0 flex flex-col bg-[var(--bg)]">
+      <nav className="flex-1 px-4 pt-2 pb-4">
         <ul className="space-y-2">
           {menuItems.map((item) => {
             const Icon = item.icon;


### PR DESCRIPTION
## Summary
- remove sticky positioning and overflow scrolling from the sidebar container so the menu stays static
- reduce the sidebar navigation's top padding to eliminate excess space above the first link

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68d3f5f22134832084550fff9e8e70fa