### PR TITLE
Fix layout height to prevent sidebar scrolling

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -66,7 +66,7 @@ const AppContent: React.FC = () => {
   const ActiveViewComponent = VIEW_COMPONENTS[activeView] ?? VIEW_COMPONENTS[DEFAULT_VIEW_ID];
 
   return (
-    <div className="min-h-screen flex flex-col bg-[var(--bg-start)]">
+    <div className="h-screen overflow-hidden flex flex-col bg-[var(--bg-start)]">
       <Header />
       <div className="flex-1 flex overflow-hidden">
         <Sidebar activeView={activeView} availablePages={availablePages} onViewChange={setActiveView} />


### PR DESCRIPTION
## Summary
- constrain the app layout to the viewport height so the sidebar remains fixed

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d3f777bec48320abfa4475c4ac4e69